### PR TITLE
Allow globbing in add() and update() AND fix defunct reset(0)

### DIFF
--- a/include/libgit4cpp/GitRepository.h
+++ b/include/libgit4cpp/GitRepository.h
@@ -95,12 +95,49 @@ public:
     /// Returns a non-owning raw pointer to the current repository.
     git_repository* get_repo();
 
-    /// Stage all new and changed files and folders in the repository directory.
+    /**
+     * Stage multiple new, changed, or removed files and folders in the repository directory.
+     *
+     * Instead of giving concrete paths to the files / objects to be added the function
+     * takes a shell like glob/wildcard:
+     * - \c * matches any number of any characters including none
+     * - \c ? matches any single character
+     * - \c [abc] matches one character given in the bracket (\c abc is example)
+     * - \c [a-z] matches one character in the range of characters (\c a-z is example)
+     * - \c \\* matches a star
+     * - \c \\? matches a question mark
+     * - \c \\\\ matches a backslash
+     * - \c \\[ matches an opening square bracket
+     *
+     * The matching happens - unlike usual shells - on the whole pathname (inside the repository).
+     * So `*` matches all files (including all subdirectories).
+     *
+     * Note: In fact you can never add a folder, you add files in a folder; i.e. it is
+     * impossible to add an empty folder. Git just knows files, not folders as items.
+     * If a file is in a folder the folder exists; if there is nothing in the folder the
+     * folder is ignored. (File means also links etc.)
+     *
+     * Note: To write \c \? into a C++ string you probably need \c "\\?" etc.
+     *
+     * Note: Globs do not match hidden files in the form of Unix dotfiles; to match them the pattern
+     * must explicitly start with \c . For example, \c * matches all visible files
+     * while \c .* matches all hidden files.
+     *
+     * \param glob  The pattern with which files are selected to be added to the index
+     *
+     * \see add_files()
+     */
     void add(const std::string& glob = "*");
 
     /**
      * Update the tracked files in the repository.
-     * This member function stages all changes of already tracked files in the repository.
+     *
+     * The same as add() but only considers files that are already in the repository, never
+     * adding just updating.
+     *
+     * \param glob  The pattern with which files are selected to be added to the index
+     *
+     * \see add() for an explanantion on the glob.
      */
     void update(const std::string& glob = "*");
 
@@ -110,6 +147,7 @@ public:
      * \return list of indices. An index from the filepaths vector is returned if
      *          the staging of the file failed. Returns an empty vector if all
      *          files were staged successfully.
+     * \see add()
      */
    std::vector <int> add_files(const std::vector<std::filesystem::path>& filepaths);
 

--- a/include/libgit4cpp/GitRepository.h
+++ b/include/libgit4cpp/GitRepository.h
@@ -238,7 +238,7 @@ private:
      * \param count Jump back count number of commits behind HEAD
      * \return C-type commit object
      */
-    LibGitPointer<git_commit> get_commit(int count);
+    LibGitPointer<git_commit> get_commit(unsigned int count = 0);
 
     /**
      * Get a specific commit.
@@ -246,12 +246,6 @@ private:
      * \return C-type commit object
      */
     LibGitPointer<git_commit> get_commit(const std::string& ref);
-
-    /**
-     * Get the HEAD commit.
-     * \return C-type commit object
-     */
-    LibGitPointer<git_commit> get_commit();
 
     /**
      * Load a git signature or create a default signature.

--- a/include/libgit4cpp/GitRepository.h
+++ b/include/libgit4cpp/GitRepository.h
@@ -81,6 +81,12 @@ public:
     void add(const std::string& glob = "*");
 
     /**
+     * Update the tracked files in the repository.
+     * This member function stages all changes of already tracked files in the repository.
+     */
+    void update(const std::string& glob = "*");
+
+    /**
      * Stage specific files listed in filepaths.
      * \param filepaths List of files. Either relative to repository root or absolute.
      * \return list of indices. An index from the filepaths vector is returned if
@@ -240,12 +246,6 @@ private:
      * \return A vector of dynamic length which contains a status struct
      */
     std::vector<FileStatus> collect_status(LibGitPointer<git_status_list>& status) const;
-
-    /**
-     * Update the tracked files in the repository.
-     * This member function stages all changes of already tracked files in the repository.
-     */
-    void update();
 
     /**
      * Basic construction code, extracted because of constructor overload

--- a/include/libgit4cpp/GitRepository.h
+++ b/include/libgit4cpp/GitRepository.h
@@ -112,7 +112,7 @@ public:
      * Hard reset of repository.
      * \param nr_of_commits number of commits to jump back
     */
-    void reset(int nr_of_commits);
+    void reset(unsigned int nr_of_commits);
 
     /**
      * Push commits to the repository.

--- a/include/libgit4cpp/GitRepository.h
+++ b/include/libgit4cpp/GitRepository.h
@@ -78,7 +78,7 @@ public:
     git_repository* get_repo();
 
     /// Stage all new and changed files and folders in the repository directory.
-    void add();
+    void add(const std::string& glob = "*");
 
     /**
      * Stage specific files listed in filepaths.

--- a/src/GitRepository.cc
+++ b/src/GitRepository.cc
@@ -87,11 +87,11 @@ git_repository* GitRepository::get_repo()
     return repo_.get();
 }
 
-void GitRepository::update()
+void GitRepository::update(const std::string& glob)
 {
     auto index = repository_index(repo_.get());
 
-    char* paths[1] = { const_cast<char*>("*") };
+    char *paths[1] = {const_cast<char*>(glob.c_str())};
     git_strarray array = { paths, 1 };
 
     // update index to check for files

--- a/src/GitRepository.cc
+++ b/src/GitRepository.cc
@@ -176,11 +176,11 @@ void GitRepository::commit(const std::string& commit_message)
         throw git::Error{ gul14::cat("Commit: ", git_error_last()->message, "\n") };
 }
 
-void GitRepository::add()
+void GitRepository::add(const std::string& glob)
 {
     auto gindex = repository_index(repo_.get());
 
-    char* paths[1] = { const_cast<char*>("*") };
+    char *paths[] = { const_cast<char*>(glob.c_str()) };
     git_strarray array = { paths, 1 };
 
     int error = git_index_add_all(gindex.get(), &array, GIT_INDEX_ADD_DEFAULT, nullptr, nullptr);

--- a/src/GitRepository.cc
+++ b/src/GitRepository.cc
@@ -308,14 +308,14 @@ bool GitRepository::is_staged(FileStatus& filestats, const git_status_entry* s)
     return true;
 }
 
-std::vector<FileStatus> GitRepository::collect_status(LibGitPointer<git_status_list>& status) const
+RepoState GitRepository::collect_status(LibGitPointer<git_status_list>& status) const
 {
     // get number of submodules
     const size_t nr_entries = git_status_list_entrycount(status.get());
 
     // declare status holding vector for each submodule
-    std::vector<FileStatus> return_array;
-    FileStatus filestats;
+    RepoState return_array{ };
+    FileStatus filestats{ };
 
     for (size_t i = 0; i < nr_entries; ++i)
     {
@@ -392,7 +392,7 @@ std::vector<FileStatus> GitRepository::collect_status(LibGitPointer<git_status_l
     return return_array;
 }
 
-std::vector<FileStatus> GitRepository::status()
+RepoState GitRepository::status()
 {
     git_status_options status_opt = GIT_STATUS_OPTIONS_INIT;
     status_opt.flags =  GIT_STATUS_OPT_INCLUDE_UNTRACKED |          // untracked files
@@ -536,7 +536,6 @@ bool GitRepository::branch_up_to_date(const std::string& branch_name)
     // Compare OIDs to check if the branches are up to date
     return git_oid_equal(local_oid, remote_oid);
 }
-
 
 } //namespace task
 

--- a/src/GitRepository.cc
+++ b/src/GitRepository.cc
@@ -426,11 +426,15 @@ std::vector<int> GitRepository::add_files(const std::vector<std::filesystem::pat
     return error_list;
 }
 
-void GitRepository::reset(int nr_of_commits)
+void GitRepository::reset(unsigned int nr_of_commits)
 {
-    const auto parent_commit = get_commit(nr_of_commits);
+    auto parent_commit = [this, nr_of_commits]() {
+            if (nr_of_commits == 0)
+                return get_commit("HEAD");
+            return get_commit(nr_of_commits);
+        }().get();
 
-    int error = git_reset(repo_.get(), (git_object*) parent_commit.get(), GIT_RESET_HARD, nullptr);
+    int error = git_reset(repo_.get(), reinterpret_cast<git_object*>(parent_commit), GIT_RESET_HARD, nullptr);
     if (error)
         throw git::Error{ gul14::cat("Reset: ", git_error_last()->message, "\n") };
 }

--- a/tests/test_GitRepository.cc
+++ b/tests/test_GitRepository.cc
@@ -100,7 +100,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitWrapper]")
      * 3) Check if files appear as untracked
      * 4) Stage all files. Now the status should show 4 staged new files
      */
-    SECTION("Stage files")
+    SECTION("Stage files (git add)")
     {
         create_testfiles("unit_test_2", 2, "Stage");
 
@@ -357,6 +357,30 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitWrapper]")
         }
 
         REQUIRE(std::filesystem::exists(gl.get_path() / mypath) == true);
+    }
+
+    SECTION("Adding with glob (git add)")
+    {
+        GitRepository gl{ reporoot };
+        auto ss = std::stringstream{ };
+        ss << gl.status();
+        REQUIRE(gul14::trim(ss.str()) == "RepoState {\n" \
+            "FileStatus{ \"unit_test_1/file0.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_1/file1.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_2/file0.txt\": untracked; untracked }\n" \
+            "FileStatus{ \"unit_test_2/file1.txt\": untracked; untracked }\n" \
+            "}");
+
+        gl.add("*le1*");
+
+        ss.str("");
+        ss << gl.status();
+        REQUIRE(gul14::trim(ss.str()) == "RepoState {\n" \
+            "FileStatus{ \"unit_test_1/file0.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_1/file1.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_2/file0.txt\": untracked; untracked }\n" \
+            "FileStatus{ \"unit_test_2/file1.txt\": staged; new file }\n" \
+            "}");
     }
 }
 

--- a/tests/test_GitRepository.cc
+++ b/tests/test_GitRepository.cc
@@ -277,15 +277,41 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitWrapper]")
         REQUIRE(std::filesystem::exists(gl.get_path() / myfile) == false);
     }
 
-    /**
-     * TODO: Fuktionalitaet von git reset implementieren
-    SECTION("Get previous commit")
+    SECTION("Get previous commit (git reset)")
     {
         GitRepository gl{ reporoot };
 
-        gl.
+        std::stringstream ss{ };
+        ss << gl.status();
+        REQUIRE(gul14::trim(ss.str()) == "RepoState {\n" \
+            "FileStatus{ \"unit_test_1/file0.txt\": unstaged; modified }\n" \
+            "FileStatus{ \"unit_test_1/file1.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_2/file0.txt\": unchanged; unchanged }\n" \
+            "}");
+
+        gl.reset(0); // `git reset --hard`: undo changes
+
+        ss.str("");
+        ss << gl.status();
+        REQUIRE(gul14::trim(ss.str()) == "RepoState {\n" \
+            "FileStatus{ \"unit_test_1/file0.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_1/file1.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_2/file0.txt\": unchanged; unchanged }\n" \
+            "}");
+
+        gl.reset(1); // `git reset --hard HEAD~1`: undo last commit
+
+        ss.str("");
+        ss << gl.status();
+        REQUIRE(gul14::trim(ss.str()) == "RepoState {\n" \
+            "FileStatus{ \"unit_test_1/file0.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_1/file1.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_2/file0.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_2/file1.txt\": unchanged; unchanged }\n" \
+            "}");
+
+        REQUIRE_THROWS(gl.reset(3)); // We do not have so many ancestors
     }
-    */
 
     /**
      * remove a directory and check if the repository status notices
@@ -436,3 +462,5 @@ TEST_CASE("GitRepository Wrapper Test Remote", "[GitWrapper]")
 
 }
 */
+
+// vi:ts=4:sw=4:sts=4:et

--- a/tests/test_GitRepository.cc
+++ b/tests/test_GitRepository.cc
@@ -42,11 +42,13 @@ auto const reporoot = std::filesystem::path{ "reporoot" };
  * Create a directory and store files in it.
  *
  * Filestructure:
+ * \code
  * reporoot/
  *      $name$/
  *          file0.txt   << $msg$ /n file0
  *          file1.txt   << $msg$ /n file1
  *          ...
+ * \endcode
  * \param name Name of the subdirectory
  * \param nr_files Number of files to be created
  * \param msg What to write to the file
@@ -403,26 +405,26 @@ TEST_CASE("GitRepository add() with glob", "[GitWrapper]")
      *
      * └── reporoot
      *     ├── .Atlantis
-     *     │   └── file0.txt
+     *     │   └── file0.txt
      *     ├── Burundi
-     *     │   ├── file0.txt
-     *     │   ├── file1.txt
-     *     │   └── file2.txt
+     *     │   ├── file0.txt
+     *     │   ├── file1.txt
+     *     │   └── file2.txt
      *     ├── Honduras
-     *     │   └── file0.txt
+     *     │   └── file0.txt
      *     ├── Japan
-     *     │   ├── file0.txt
-     *     │   ├── file1.txt
-     *     │   ├── Hokkaido
-     *     │   │   └── file0.txt
-     *     │   └── Hyogo
-     *     │       ├── file0.txt
-     *     │       └── file1.txt
+     *     │   ├── file0.txt
+     *     │   ├── file1.txt
+     *     │   ├── Hokkaido
+     *     │   │   └── file0.txt
+     *     │   └── Hyogo
+     *     │       ├── file0.txt
+     *     │       └── file1.txt
      *     ├── Malaysia
-     *     │   └── file0.txt
+     *     │   └── file0.txt
      *     ├── Paraguay
-     *     │   ├── file0.txt
-     *     │   └── file1.txt
+     *     │   ├── file0.txt
+     *     │   └── file1.txt
      *     └── Peru
      *         ├── file0.txt
      *         └── file1.txt

--- a/tests/test_GitRepository.cc
+++ b/tests/test_GitRepository.cc
@@ -28,8 +28,7 @@
 
 #include <git2.h>
 #include <gul14/catch.h>
-#include <gul14/cat.h>
-#include <gul14/substring_checks.h>
+#include <gul14/gul.h>
 
 #include "libgit4cpp/GitRepository.h"
 #include "libgit4cpp/wrapper_functions.h"
@@ -208,6 +207,16 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitWrapper]")
                 REQUIRE(elm.changes == "unchanged");
             }
         }
+
+        // Try the dump to stream operator with some 'interesting' state:
+        std::stringstream ss{ };
+        ss << stats;
+        REQUIRE(gul14::trim(ss.str()) == "RepoState {\n" \
+            "FileStatus{ \"unit_test_1/file0.txt\": unstaged; modified }\n" \
+            "FileStatus{ \"unit_test_1/file1.txt\": unstaged; modified }\n" \
+            "FileStatus{ \"unit_test_2/file0.txt\": unchanged; unchanged }\n" \
+            "FileStatus{ \"unit_test_2/file1.txt\": unchanged; unchanged }\n" \
+            "}");
 
         auto ret = gl.add_files({"unit_test_1/file1.txt"});
 


### PR DESCRIPTION
**[why]**

We can only add specific files are all files.
It is not possible to add a whole subdirectory via glob.

With add() we can not add removed files. For some unknown reason add()
is public but update() is not.

**[how]**

Forward glob string to libgit2 add() function.

Make update() public.
Allow globs to be specified for update(), to allow updating whole
subdirectories and not only the complete repository.
