### PR TITLE
Improve debian packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build*/
+subprojects/*/
+docs/html/
 .vscode/settings.json
 .vscode/cspell.json

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,16 +1,21 @@
-This is Debian/GNU Linux's version of the libgit4cpp library
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
-Copyright (C) 2022 DESY lars.froehlich@desy.de
+Files: *
+Copyright: 2023 libgit4cpp contributors
+           2023 DESY
+License: LGPL-2.1+
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU Lesser General Public License as published
-   by the Free Software Foundation, either version 2.1 of the license, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU Lesser General Public License for more details.
-
-   You should have received a copy of the GNU Lesser General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+License: LGPL-2.1+
+ This package is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU Lesser General Public
+ License along with this package; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA


### PR DESCRIPTION
The debian packaging here is not nicely integrated with the concept that the files in the repo **are not touched** when building, and that different build setups can exist in different build directories.

In fact the obsolete `check_control` etc files are used. I would strongly discourage this. This seems to happen in a lot of the libs, but I guess this is just copy & pasted from older libs. We should break free from that scheme, imho.
Furthermore, if we develop on git, still the best solution for the `changelog` is in my eyes the changelog-from-git generator.
That is also not used.

Furthermore there is no mechanism that prevents to packetize a dirty repo (i.e. with local changes).

If you run this through `lintian`  you also see that the `copyright` file is so old style, that it smells ;)

At the moment I just correct the copyright file here. I also have commits locally that fix the other issues, but maybe we should talk about that before I propose any change on that.

The same holds for the Doxygen btw, it ALSO changes files in-repo :-(