### PR TITLE
Improve doc and test on remove_*()

### DIFF
--- a/include/libgit4cpp/GitRepository.h
+++ b/include/libgit4cpp/GitRepository.h
@@ -134,15 +134,33 @@ public:
 
     /**
      * Remove all entries from the index under a given directory.
+     *
+     * No files are removed from the filesystem.
+     *
      * \param directory Directory to remove
      * \attention Directory is a relative path within repo_path_
+     * \See remove_files() for hints about file removal
      */
     void remove_directory(const std::filesystem::path& directory);
 
     /**
      * Delete specific files from git index.
+     *
+     * No files are removed from the filesystem.
+     *
+     * They also do not need to exist on the filesystem to be removable from the index.
+     *
+     * To delete files from the repository you can eiter:
+     *
+     * - remove the files from the repository With remove_files()
+     * - and remove the files from the filesystem with \c std::filesystem::remove()
+     *
+     * - remove the files from the filesystem with \c std::filesystem::remove()
+     * - add the removal of the files with add_files() or with remove_files()
+     *
      * \param filepaths list of files
      * \attention files in filepaths are relative to repo_path_
+     * \see remove_directory()
     */
     void remove_files(const std::vector<std::filesystem::path>& filepaths);
 

--- a/tests/test_GitRepository.cc
+++ b/tests/test_GitRepository.cc
@@ -247,6 +247,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitWrapper]")
         GitRepository gl{"sequences"};
 
         std::filesystem::path myfile = "unit_test_2/file1.txt";
+        REQUIRE(std::filesystem::exists(gl.get_path() / myfile) == true);
 
         gl.remove_files({myfile});
 
@@ -265,8 +266,9 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitWrapper]")
 
         gl.commit("remove file");
 
-
+        REQUIRE(std::filesystem::exists(gl.get_path() / myfile) == true);
         std::filesystem::remove("sequences/unit_test_2/file1.txt");
+        REQUIRE(std::filesystem::exists(gl.get_path() / myfile) == false);
     }
 
     /**
@@ -284,8 +286,8 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitWrapper]")
      * 1) Delete unit_test_2
      * 2) Files should be automatically staged for deletion
      * 3) Commit removal
-     * 4) check if files are gone from status
-     * 5) check if files are gone from filesystem
+     * 4) check if files are gone from status (should)
+     * 5) check if files are gone from filesystem (should not)
      */
     SECTION("Delete Directory")
     {
@@ -293,6 +295,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitWrapper]")
         GitRepository gl{"sequences"};
 
         std::filesystem::path mypath = "unit_test_2";
+        REQUIRE(std::filesystem::exists(gl.get_path() / mypath) == true);
 
         gl.remove_directory(mypath);
 
@@ -320,6 +323,8 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitWrapper]")
             if (gul14::starts_with(elm.path_name, "unit_test_2/file"))
                 REQUIRE (elm.changes == "untracked");
         }
+
+        REQUIRE(std::filesystem::exists(gl.get_path() / mypath) == true);
     }
 }
 


### PR DESCRIPTION
**[why]**
People might wonder if remove_files() does remove the files just from the index or also from the filesystem.

The command-line `git rm fasel.cc` does remove the file; so that might be expected. But the GitRepository functions just manipulate the index and leave the real files in existence (or absense).

The user has more freedom to manipulate the index in this way, for example a subdirectory can be removed from the index (but still exists locally), that change is commited and pushed to the remote repo and only on fetch the local repository shows the centrally managed state.

**[how]**
Leave implmentation as it is.
Add tests and documentation.

---

Note: The test has been described in the comment in the tests, but not been coded.