### PR TITLE
Remove debug output

### DIFF
--- a/include/libgit4cpp/wrapper_functions.h
+++ b/include/libgit4cpp/wrapper_functions.h
@@ -37,42 +37,43 @@ namespace git {
 
 /**
  * Function wrappers for libgit2 functions which manipulate pointers.
- * (Which take double pointers as parameters)
- * \note for documentation see the associated libgit2 function
+ * (Which take a pointer to a pointer as output parameter)
+ * \note For documentation see the associated libgit2 function
  *       name: "git_FUNCTIONNAME"
  * \defgroup lgptrfunc Group of wrapped libgit2 functions
  * \{
  */
 
- /**
-  * Return an existing repository.
-  * \param repo_path absolute or relative path from executable
-  * \return Wrapper of a git_repository*
- */
+/**
+ * Open an existing repository.
+ * \param repo_path Absolute or relative path to the repository root
+ * \return new git_repository object for the opened repository
+*/
 LibGitPointer<git_repository>
 repository_open(const std::string& repo_path);
 
 /**
- * Return a fresh initialized repository.
- * \param repo_path absolute or relative path from executable
- * \param is_bare if true, a git repo is created at repo_path. Else, .git is created in repo_path.
- * \return Wrapper of a git_repository*
+ * Initialize a fresh repository.
+ * \param repo_path Absolute or relative path to the repository root
+ * \param is_bare If true, a git repo is created at repo_path. Else, .git is created in repo_path.
+ * \return new git_repository object for the created repository
 */
 LibGitPointer<git_repository>
 repository_init(const std::string& repo_path, bool is_bare);
 
 /**
  * Return the current index of a repository.
- * \param repo C-type repository
- * \return Wrapper of a git_index*
+ * \param repo Pointer to the repository object
+ * \return new git_index object
 */
 LibGitPointer<git_index>
 repository_index(git_repository* repo);
 
 /**
- * Generate a signature from system values (already collected by the C-type repository).
- * \param repo_path absolute or relative path from executable
- * \return Wrapper of a git_signature*
+ * Generate a signature from system values.
+ * Defaults deduced from existing repository object.
+ * \param repo Pointer to repository object to use for defaults
+ * \return new git_signature object
 */
 LibGitPointer<git_signature>
 signature_default(git_repository* repo);
@@ -81,46 +82,47 @@ signature_default(git_repository* repo);
  * Generate a signature from given parameters.
  * \param name User name who creates the commit
  * \param email E-mail of the user
- * \param time timestamp
- * \param offset timezone adjustment for the timezone
- * \return Wrapper of a git_signature*
+ * \param time Unix time of the creation date
+ * \param offset Timezone adjustment for the timestamp
+ * \return new git_signature object
 */
 LibGitPointer<git_signature>
 signature_new(const std::string& name, const std::string& email, time_t time, int offset);
 
 
 /**
- * Collect the current tree of the git repository.
- * \param repo C-type repository
- * \param tree_id identity number of the active tree
- * \return Wrapper of a git_signature*
+ * Collect the current tree of a git repository.
+ * \param repo Pointer to repository object to examine
+ * \param tree_id Identity number of the active tree
+ * \return new git_tree object
 */
 LibGitPointer<git_tree>
 tree_lookup(git_repository* repo, git_oid tree_id);
 
 /**
- * Create a new status list which contains status_list_entry* elements
- * \param repo C-type repository
- * \param status_opt struct of status options
- * \return Wrapper of git_status_list*
+ * Create a new status list of the index.
+ * The returned status object contains status_list_entry* elements.
+ * \param repo Pointer to repository object
+ * \param status_opt Struct of status options
+ * \return new git_status_list object
 */
 LibGitPointer<git_status_list>
 status_list_new(git_repository* repo, const git_status_options& status_opt);
 
 /**
  * Collect the reference to the repository head.
- * \param repo C-type repository
- * \return Wrapper of git_reference*
+ * \param repo Pointer to repository object
+ * \return new git_reference object
  */
 LibGitPointer<git_reference>
 repository_head(git_repository* repo);
 
 /**
- * Create a new remote connection in the repository and returns it
- * \param repo C-type repository
- * \param remote_name typically 'origin'
- * \param url adress of remote connection, e.g https://github.com/...
- * \return Wrapper of a remote connection
+ * Create a new remote connection in the repository.
+ * \param repo Pointer to repository object
+ * \param remote_name Name of the remote, e.g. "origin"
+ * \param url Adress of remote connection, e.g https://github.com/...
+ * \return new git_remote object
  */
 LibGitPointer<git_remote>
 remote_create (git_repository* repo, const std::string& remote_name,
@@ -128,10 +130,10 @@ remote_create (git_repository* repo, const std::string& remote_name,
 
 
 /**
- * Collects the remove connection by name and returns it
- * \param repo C-type repository
- * \param remote_name typically 'origin'
- * \return Wrapper of a remote connection
+ * Collects the remove connection by name.
+ * \param repo Pointer to repository object
+ * \param remote_name Name of the remote, e.g. "origin"
+ * \return new git_remote object
  */
 LibGitPointer<git_remote>
 remote_lookup (git_repository* repo, const std::string& remote_name);
@@ -139,37 +141,36 @@ remote_lookup (git_repository* repo, const std::string& remote_name);
 
 
 /**
- * Clone existing git repository into local filesystem
- * \param url adress of remote connection, e.g https://github.com/...
- * \param repo_path absolute or relative path from executable
- * \return Wrapper of a repository
+ * Clone existing git repository into local filesystem.
+ * \param url Address of remote connection, e.g https://github.com/...
+ * \param repo_path Absolute or relative path to the repository root
+ * \return new git_repository object
 */
 LibGitPointer<git_repository>
 clone (const std::string& url, const std::string& repo_path);
 
 
 /**
- * Find the reference to a branch where the name is known
- * \param repo C-type repository
- * \param branch_name e.g. 'master', '3_fix bugs', etc...
- * \param branch_type enum with 1=GIT_BRANCH_LOCAL, 2=GIT_BRANCH_REMOTE, 3=GIT_BRANCH_ALL
- * \return Wrapper of git reference
+ * Find a named branch.
+ * \param repo Pointer to repository object
+ * \param branch_name The name to search for, e.g. 'main', 'fix-bugs'
+ * \param branch_type Which branch type to find, enum with 1=GIT_BRANCH_LOCAL, 2=GIT_BRANCH_REMOTE, 3=GIT_BRANCH_ALL
+ * \return new git_reference object
 */
 LibGitPointer<git_reference>
 branch_lookup(git_repository* repo, const std::string& branch_name, git_branch_t branch_type);
 
 
 /**
- * Return the name of a remote name
- * \param repo C-type repository
- * \param branch_name e.g. 'master', '3_fix bugs', etc...
- * \return remote name, typically 'origin/master' or 'origin/3_fix_bugs'
- * 
+ * Find the name of a branch on the remote.
+ * \param repo Pointer to repository object
+ * \param branch_name Local branch name, e.g. 'main', 'fix-bugs'
+ * \return name on remote , e.g. 'origin/main' or 'origin/fix-bugs'
 */
 std::string
 branch_remote_name(git_repository* repo, const std::string& branch_name);
 
-/** \}*/
+/** \} */ // end of group lgptrfunc
 
 } // namespace git
 

--- a/src/GitRepository.cc
+++ b/src/GitRepository.cc
@@ -43,7 +43,7 @@ GitRepository::GitRepository(const std::filesystem::path& file_path, const std::
 
     //check if remote already exists, else create new remote
     auto remote_ = remote_lookup(repo_.get(), "origin");
-    if (remote_.get() == nullptr)
+    if (not remote_)
         remote_ = remote_create(repo_.get(), "origin", url.c_str());
 }
 
@@ -58,7 +58,7 @@ GitRepository::~GitRepository()
 void GitRepository::make_signature()
 {
     my_signature_ = signature_default(repo_.get());
-    if (my_signature_.get() == nullptr)
+    if (not my_signature_)
         my_signature_ = signature_new("Taskomat", "(none)", std::time(0), 0);
 }
 
@@ -103,12 +103,12 @@ void GitRepository::init(const std::filesystem::path& file_path)
 {
     repo_ = repository_open(repo_path_);
 
-    if (repo_.get() == nullptr)
+    if (not repo_)
     {
         // create repository
         // 2nd argument: false so that .git folder is created in given path
         repo_ = repository_init(file_path, false);
-        if (repo_.get() == nullptr)
+        if (not repo_)
             throw git::Error{ "Git init failed" };
 
         make_signature();
@@ -399,7 +399,7 @@ RepoState GitRepository::status()
                         GIT_STATUS_OPT_INCLUDE_IGNORED;             // ignored files
 
     auto my_status = status_list_new(repo_.get(), status_opt);
-    if (my_status.get() == nullptr)
+    if (not my_status)
         throw git::Error{ "Cannot initialize status" };
 
     return collect_status(my_status);
@@ -443,7 +443,7 @@ void GitRepository::push()
     // set remote
     /*
     auto remote = remote_lookup(repo_.get(), "origin");
-    if (remote.get() == nullptr)
+    if (not remote)
         throw git::Error{ "Cannot find remote object." };
     */
 
@@ -462,7 +462,7 @@ void GitRepository::pull()
     // set remote
     /*
     auto remote = remote_lookup(repo_.get(), "origin");
-    if (remote.get() == nullptr)
+    if (not remote)
         throw git::Error{ "Cannot find remote object" };
     */
 
@@ -483,7 +483,7 @@ void GitRepository::pull()
 void GitRepository::clone_repo(const std::string& url, const std::filesystem::path& repo_path )
 {
     auto repo = clone(url, repo_path);
-    if (repo.get() == nullptr) {
+    if (not repo) {
         throw git::Error{ "Cannot clone repository" };
     }
     else
@@ -500,7 +500,7 @@ void GitRepository::clone_repo(const std::string& url, const std::filesystem::pa
 bool GitRepository::branch_up_to_date(const std::string& branch_name)
 {
     auto local_ref = branch_lookup(repo_.get(), "master", GIT_BRANCH_LOCAL);
-    if (local_ref.get() == nullptr)
+    if (not local_ref)
         throw git::Error{ gul14::cat("Branch lookup: ", git_error_last()->message) };
 
     // Get the name of the remote associated with the local branch
@@ -511,7 +511,7 @@ bool GitRepository::branch_up_to_date(const std::string& branch_name)
 
     // Open the remote
     auto remote = remote_lookup(repo_.get(), remote_name);
-    if (remote.get() == nullptr)
+    if (not remote)
         throw git::Error{ "Cannot find remote object" };
 
     // Get the upstream branch

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -41,7 +41,7 @@ repository_open(const std::string& repo_path)
         repo=nullptr;
     }
 
-    return LibGitPointer(repo);
+    return repo;
 }
 
 LibGitPointer<git_repository>
@@ -54,7 +54,7 @@ repository_init(const std::string& repo_path, bool is_bare)
         std::cout << gul14::cat("repository_init: ", git_error_last()->message, "\n");
         repo = nullptr;
     }
-    return LibGitPointer(repo);
+    return repo;
 }
 
 LibGitPointer<git_index>
@@ -66,7 +66,7 @@ repository_index(git_repository* repo)
         std::cout << gul14::cat("repository_index: ", git_error_last()->message, "\n");
         index = nullptr;
     }
-    return LibGitPointer(index);
+    return index;
 }
 
 LibGitPointer<git_signature>
@@ -78,7 +78,7 @@ signature_default(git_repository* repo)
         std::cout << gul14::cat("signature_default: ", git_error_last()->message, "\n");
         signature = nullptr;
     }
-    return LibGitPointer(signature);
+    return signature;
 }
 
 LibGitPointer<git_signature>
@@ -90,7 +90,7 @@ signature_new(const std::string& name, const std::string& email, time_t time, in
         std::cout << gul14::cat("signature_new: ", git_error_last()->message, "\n");
         signature = nullptr;
     }
-    return LibGitPointer(signature);
+    return signature;
 }
 
 LibGitPointer<git_tree>
@@ -102,7 +102,7 @@ tree_lookup(git_repository* repo, git_oid tree_id)
         std::cout << gul14::cat("tree_lookup: ", git_error_last()->message, "\n");
         tree = nullptr;
     }
-    return LibGitPointer(tree);
+    return tree;
 }
 
 LibGitPointer<git_remote>
@@ -115,7 +115,7 @@ remote_create(git_repository* repo, const std::string& remote_name,
         std::cout << gul14::cat("remote_create: ", git_error_last()->message, "\n");
         remote = nullptr;
     }
-    return LibGitPointer(remote);
+    return remote;
 }
 
 LibGitPointer<git_remote>
@@ -127,7 +127,7 @@ remote_lookup(git_repository* repo, const std::string& remote_name)
         std::cout << gul14::cat("remote_lookup: ", git_error_last()->message, "\n");
         remote = nullptr;
     }
-    return LibGitPointer(remote);
+    return remote;
 }
 
 LibGitPointer<git_status_list>
@@ -139,7 +139,7 @@ status_list_new(git_repository* repo, const git_status_options& status_opt)
         std::cout << gul14::cat("status_list_new: ", git_error_last()->message, "\n");
         status = nullptr;
     }
-    return LibGitPointer(status);
+    return status;
 }
 
 LibGitPointer<git_reference>
@@ -151,7 +151,7 @@ repository_head(git_repository* repo)
         std::cout << gul14::cat("reposiotry_head: ", git_error_last()->message, "\n");
         reference = nullptr;
     }
-    return LibGitPointer(reference);
+    return reference;
 }
 
 LibGitPointer<git_repository>
@@ -163,7 +163,7 @@ clone (const std::string& url, const std::string& repo_path)
         std::cout << gul14::cat("branch_remote_name: ", git_error_last()->message, "\n");
         repo = nullptr;
     }
-    return LibGitPointer(repo);
+    return repo;
 
 }
 
@@ -176,7 +176,7 @@ branch_lookup(git_repository* repo, const std::string& branch_name, git_branch_t
         std::cout << gul14::cat("branch_lookup: ", git_error_last()->message, "\n");
         ref = nullptr;
     }
-    return LibGitPointer(ref);
+    return ref;
 }
 
 std::string

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -24,7 +24,6 @@
 
 #include <git2.h>
 #include <gul14/cat.h>
-#include<iostream>
 
 #include "libgit4cpp/wrapper_functions.h"
 #include "libgit4cpp/Error.h"
@@ -34,74 +33,55 @@ namespace git {
 LibGitPointer<git_repository>
 repository_open(const std::string& repo_path)
 {
-    git_repository *repo;
+    git_repository* repo;
     if (git_repository_open(&repo, repo_path.c_str()))
-    {
-        std::cout << gul14::cat("repository_open: ", git_error_last()->message, "\n");
-        repo=nullptr;
-    }
-
+        return gul14::cat("repository_open: ", git_error_last()->message);
     return repo;
 }
 
 LibGitPointer<git_repository>
 repository_init(const std::string& repo_path, bool is_bare)
 {
-    git_repository *repo;
+    git_repository* repo;
     int error = git_repository_init(&repo, repo_path.c_str(), is_bare);
     if (error)
-    {
-        std::cout << gul14::cat("repository_init: ", git_error_last()->message, "\n");
-        repo = nullptr;
-    }
+        return gul14::cat("repository_init: ", git_error_last()->message);
     return repo;
 }
 
 LibGitPointer<git_index>
 repository_index(git_repository* repo)
 {
-    git_index *index;
+    git_index* index;
     if (git_repository_index(&index, repo))
-    {
-        std::cout << gul14::cat("repository_index: ", git_error_last()->message, "\n");
-        index = nullptr;
-    }
+        return gul14::cat("repository_index: ", git_error_last()->message);
     return index;
 }
 
 LibGitPointer<git_signature>
 signature_default(git_repository* repo)
 {
-    git_signature *signature;
+    git_signature* signature;
     if (git_signature_default(&signature, repo))
-    {
-        std::cout << gul14::cat("signature_default: ", git_error_last()->message, "\n");
-        signature = nullptr;
-    }
+        return gul14::cat("signature_default: ", git_error_last()->message);
     return signature;
 }
 
 LibGitPointer<git_signature>
 signature_new(const std::string& name, const std::string& email, time_t time, int offset)
 {
-    git_signature *signature;
+    git_signature* signature;
     if (git_signature_new(&signature, name.c_str(), email.c_str(), time, offset))
-    {
-        std::cout << gul14::cat("signature_new: ", git_error_last()->message, "\n");
-        signature = nullptr;
-    }
+        return gul14::cat("signature_new: ", git_error_last()->message);
     return signature;
 }
 
 LibGitPointer<git_tree>
 tree_lookup(git_repository* repo, git_oid tree_id)
 {
-    git_tree *tree;
+    git_tree* tree;
     if (git_tree_lookup(&tree, repo, &tree_id))
-    {
-        std::cout << gul14::cat("tree_lookup: ", git_error_last()->message, "\n");
-        tree = nullptr;
-    }
+        return gul14::cat("tree_lookup: ", git_error_last()->message);
     return tree;
 }
 
@@ -109,48 +89,36 @@ LibGitPointer<git_remote>
 remote_create(git_repository* repo, const std::string& remote_name,
               const std::string& url)
 {
-    git_remote *remote;
+    git_remote* remote;
     if (git_remote_create(&remote, repo, remote_name.c_str(), url.c_str()))
-    {
-        std::cout << gul14::cat("remote_create: ", git_error_last()->message, "\n");
-        remote = nullptr;
-    }
+        return gul14::cat("remote_create: ", git_error_last()->message);
     return remote;
 }
 
 LibGitPointer<git_remote>
 remote_lookup(git_repository* repo, const std::string& remote_name)
 {
-    git_remote *remote;
+    git_remote* remote;
     if (git_remote_lookup(&remote, repo, remote_name.c_str()))
-    {
-        std::cout << gul14::cat("remote_lookup: ", git_error_last()->message, "\n");
-        remote = nullptr;
-    }
+        return gul14::cat("remote_lookup: ", git_error_last()->message);
     return remote;
 }
 
 LibGitPointer<git_status_list>
 status_list_new(git_repository* repo, const git_status_options& status_opt)
 {
-    git_status_list *status;
+    git_status_list* status;
     if (git_status_list_new(&status, repo, &status_opt))
-    {
-        std::cout << gul14::cat("status_list_new: ", git_error_last()->message, "\n");
-        status = nullptr;
-    }
+        return gul14::cat("status_list_new: ", git_error_last()->message);
     return status;
 }
 
 LibGitPointer<git_reference>
 repository_head(git_repository* repo)
 {
-    git_reference *reference;
+    git_reference* reference;
     if (git_repository_head(&reference, repo))
-    {
-        std::cout << gul14::cat("reposiotry_head: ", git_error_last()->message, "\n");
-        reference = nullptr;
-    }
+        return gul14::cat("reposiotry_head: ", git_error_last()->message);
     return reference;
 }
 
@@ -159,10 +127,7 @@ clone (const std::string& url, const std::string& repo_path)
 {
     git_repository* repo;
     if (git_clone(&repo, url.c_str(), repo_path.c_str(), nullptr))
-    {
-        std::cout << gul14::cat("branch_remote_name: ", git_error_last()->message, "\n");
-        repo = nullptr;
-    }
+        return gul14::cat("branch_remote_name: ", git_error_last()->message);
     return repo;
 
 }
@@ -172,10 +137,7 @@ branch_lookup(git_repository* repo, const std::string& branch_name, git_branch_t
 {
     git_reference* ref;
     if (git_branch_lookup(&ref, repo, branch_name.c_str(), branch_type))
-    {
-        std::cout << gul14::cat("branch_lookup: ", git_error_last()->message, "\n");
-        ref = nullptr;
-    }
+        return gul14::cat("branch_lookup: ", git_error_last()->message);
     return ref;
 }
 
@@ -184,10 +146,7 @@ branch_remote_name(git_repository* repo, const std::string& branch_name)
 {
     git_buf buf;
     if (git_branch_remote_name(&buf, repo, branch_name.c_str()))
-    {
-        std::cout << gul14::cat("branch_remote_name: ", git_error_last()->message, "\n");
-        return "";
-    }
+        return gul14::cat("branch_remote_name: ", git_error_last()->message);
     return buf.ptr;
 }
 


### PR DESCRIPTION
The wrapper functions output some error messages to stderr when something happens.
Sometimes the error is "expected" but the message is printed nonetheless.
For example
* A repository is to be opened or created...
* It tries to open the repo via libgit2
* If that fails a new repo is created

We have 2 possibilities...

1. Keep the error messages but only throw them when they are unexpected.
   For this we expand the LibGitWrapper to be a bit like a gul14::expected
   (which is, I just noticed, quite different from std::expected).
   This is implemented in the PR.
2. Just drop the error messages and hope all errors are handled by the wrapper users.

Fixes: #5 

I'm not sure what we want, 1 or 2 or something else. Please feel free to suggest something different, etc.
I know tests for the extension of LibGitWrapper are missing, I wanted to wait until I know we really want that ;-)

_Edit: Add last sentense_