### PR TITLE
Use "main" for head

### DIFF
--- a/src/GitRepository.cc
+++ b/src/GitRepository.cc
@@ -43,7 +43,7 @@ GitRepository::GitRepository(const std::filesystem::path& file_path, const std::
 
     //check if remote already exists, else create new remote
     auto remote_ = remote_lookup(repo_.get(), "origin");
-    if (remote_.get() == nullptr)
+    if (remote_.get() == nullptr and not url.empty())
         remote_ = remote_create(repo_.get(), "origin", url.c_str());
 }
 

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -48,7 +48,12 @@ LibGitPointer<git_repository>
 repository_init(const std::string& repo_path, bool is_bare)
 {
     git_repository *repo;
-    int error = git_repository_init(&repo, repo_path.c_str(), is_bare);
+    git_repository_init_options opts;
+    git_repository_init_init_options(&opts, GIT_REPOSITORY_INIT_OPTIONS_VERSION);
+    if (is_bare)
+        opts.flags |= GIT_REPOSITORY_INIT_BARE;
+    opts.initial_head = "main";
+    int error = git_repository_init_ext(&repo, repo_path.c_str(), &opts);
     if (error)
     {
         std::cout << gul14::cat("repository_init: ", git_error_last()->message, "\n");

--- a/tests/test_GitRepository.cc
+++ b/tests/test_GitRepository.cc
@@ -36,6 +36,8 @@
 using namespace git;
 using gul14::cat;
 
+namespace {
+
 auto const reporoot = std::filesystem::path{ "reporoot" };
 
 /**
@@ -66,6 +68,8 @@ void create_testfiles(const std::filesystem::path& name, size_t nr_files,
         f << msg << cat("\nfile", i);
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("GitRepository Wrapper Test all", "[GitWrapper]")
 {


### PR DESCRIPTION
The repo uses "master" locally as default head.
I believe we want to use "main".

Also fix 2 small other things en passant.