### PR TITLE
Bugfix repo init

### DIFF
--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -48,6 +48,7 @@ LibGitRepository repository_init(const std::string& repo_path, bool is_bare)
     git_repository_init_init_options(&opts, GIT_REPOSITORY_INIT_OPTIONS_VERSION);
     if (is_bare)
         opts.flags |= GIT_REPOSITORY_INIT_BARE;
+    opts.flags |= GIT_REPOSITORY_INIT_MKPATH;
     opts.initial_head = "main";
     git_repository* repo;
     int error = git_repository_init_ext(&repo, repo_path.c_str(), &opts);

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -24,7 +24,6 @@
 
 #include <git2.h>
 #include <gul14/cat.h>
-#include<iostream>
 
 #include "libgit4cpp/wrapper_functions.h"
 #include "libgit4cpp/Error.h"


### PR DESCRIPTION
We had the wrong default when we changed the repo creation function.
Before: `git_repository_init()`
Now: `git_repository_init_ext()`

This turned only up in downstream tests.
Maybe add tests for this later (i.e. after rerelease), now in a conference.

**Note the comment in this gitlib2 code** 😬 

<img width="883" alt="Screenshot 2023-12-13 at 19 24 11" src="https://github.com/taskolib/libgit4cpp/assets/16012374/2023eb01-ca22-45fa-9a2a-cfb2e62b57a1">
