### PR TITLE
Feature/remotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ subprojects/*/
 docs/html/
 .vscode/settings.json
 .vscode/cspell.json
-unit_test_files
+unit_test_files/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ subprojects/*/
 docs/html/
 .vscode/settings.json
 .vscode/cspell.json
+unit_test_files

--- a/include/libgit4cpp/GitRepository.h
+++ b/include/libgit4cpp/GitRepository.h
@@ -172,8 +172,15 @@ public:
 
     /**
      * Add a new git remote with the specified name and URL to the repository.
+     * \returns a Remote object representing the newly added remote
      * \exception Error is thrown if the remote cannot be added, for instance because it
      *            already exists.
+     *
+     * \code{.cpp}
+     * GitRepository repo{ "/path/to/repo" };
+     * repo.add_remote("origin", "https://gitlab.com/a/b.git");
+     * repo.add_remote("upstream", "file:///path/to/upstream/repo");
+     * \endcode
      */
     Remote add_remote(const std::string& remote_name, const std::string& url);
 
@@ -189,13 +196,20 @@ public:
      */
     gul14::SmallVector<Remote, 2> list_remotes() const;
 
-#if 0
     /**
-     * Push commits to the repository.
-     * \param addr Address of the remote git repository host
+     * Push something to the specified remote.
+     *
+     * In git parlance, this updates a remote ref from a local ref. The "refspec"
+     * specifies which local ref and which remote ref is used. For instance, the default
+     * "HEAD:refs/heads/main" pushes HEAD (whatever is currently checked out in the local
+     * working directory) to the remote branch "main".
+     *
+     * \param remote   The git remote to push to (e.g. obtained by get_remote())
+     * \param refspec  The refspec to push (e.g. "HEAD" or "refs/heads/main")
      */
-    void push();
+    void push(const Remote& remote, const std::string& refspec = "HEAD:refs/heads/main");
 
+#if 0
     /**
      * Pull changes from the remote repository.
      * \param addr Address of the git repository host

--- a/include/libgit4cpp/GitRepository.h
+++ b/include/libgit4cpp/GitRepository.h
@@ -170,6 +170,25 @@ public:
     */
     void reset(unsigned int nr_of_commits);
 
+    /**
+     * Add a new git remote with the specified name and URL to the repository.
+     * \exception Error is thrown if the remote cannot be added, for instance because it
+     *            already exists.
+     */
+    Remote add_remote(const std::string& remote_name, const std::string& url);
+
+    /**
+     * Look up a git remote by name in the repository.
+     * \returns a Remote object if the remote exists, or an empty optional otherwise.
+     */
+    gul14::optional<Remote> get_remote(const std::string& remote_name) const;
+
+    /**
+     * Return a list of all configured git remotes.
+     * \exception Error is thrown if the remote list cannot be retrieved.
+     */
+    gul14::SmallVector<Remote, 2> list_remotes() const;
+
 #if 0
     /**
      * Push commits to the repository.

--- a/include/libgit4cpp/GitRepository.h
+++ b/include/libgit4cpp/GitRepository.h
@@ -4,7 +4,7 @@
  * \date   Created on March 20, 2023
  * \brief  Wrapper for C-Package libgit2
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -31,7 +31,9 @@
 
 #include <git2.h>
 #include <gul14/escape.h>
+#include <gul14/SmallVector.h>
 
+#include "libgit4cpp/Remote.h"
 #include "libgit4cpp/types.h"
 
 namespace git {
@@ -80,9 +82,8 @@ public:
     /**
      * Constructor which specifies the root dir of the git repository.
      * \param file_path  Path to git directory
-     * \param url        Optional remote repository url
      */
-    explicit GitRepository(const std::filesystem::path& file_path, const std::string& url = { });
+    explicit GitRepository(const std::filesystem::path& file_path);
 
     /**
      * Reset all knowledge this object knows about the repository and load the knowledge again.
@@ -169,16 +170,17 @@ public:
     */
     void reset(unsigned int nr_of_commits);
 
+#if 0
     /**
      * Push commits to the repository.
      * \param addr Address of the remote git repository host
-    */
+     */
     void push();
 
     /**
      * Pull changes from the remote repository.
      * \param addr Address of the git repository host
-    */
+     */
     void pull();
 
     /**
@@ -192,6 +194,7 @@ public:
      * \param branch_name
     */
     bool branch_up_to_date(const std::string& branch_name);
+#endif
 
     /**
      * Remove all entries from the index under a given directory.
@@ -243,12 +246,6 @@ private:
 
     /// Path to the repository.
     std::filesystem::path repo_path_;
-
-    /// URL of the remote repository.
-    std::string url_;
-
-    /// git remote object
-    LibGitRemote remote_{ nullptr, git_remote_free };
 
     /// Pointer which holds all infos of the active repository.
     LibGitRepository repo_{ nullptr, git_repository_free };

--- a/include/libgit4cpp/GitRepository.h
+++ b/include/libgit4cpp/GitRepository.h
@@ -31,7 +31,6 @@
 
 #include <git2.h>
 #include <gul14/escape.h>
-#include <gul14/SmallVector.h>
 
 #include "libgit4cpp/Remote.h"
 #include "libgit4cpp/types.h"
@@ -191,10 +190,17 @@ public:
     gul14::optional<Remote> get_remote(const std::string& remote_name) const;
 
     /**
-     * Return a list of all configured git remotes.
+     * Return a list of all configured remote repositories.
+     * \exception Error is thrown if the list cannot be retrieved.
+     */
+    std::vector<Remote> list_remotes() const;
+
+    /**
+     * Return a list containing the names of all configured remote repositories (such as
+     * "origin").
      * \exception Error is thrown if the remote list cannot be retrieved.
      */
-    gul14::SmallVector<Remote, 2> list_remotes() const;
+    std::vector<std::string> list_remote_names() const;
 
     /**
      * Push something to the specified remote.

--- a/include/libgit4cpp/Remote.h
+++ b/include/libgit4cpp/Remote.h
@@ -36,10 +36,11 @@
 namespace git {
 
 /**
- * An abstraction of a git remote (such as "origin").
+ * An abstraction of a git remote repository (such as "origin").
  *
  * A remote has a name and a URL which can be accessed via get_name() and get_url(),
- * respectively.
+ * respectively. In addition, a non-owning pointer to the underlying git_remote object
+ * can be retrieved via get().
  */
 class Remote
 {
@@ -56,10 +57,10 @@ public:
     git_remote* get() const { return remote_.get(); }
 
     /// Return the name of the remote (e.g. "origin"). May be empty for in-memory remotes.
-    const std::string& get_name() const { return name_; }
+    std::string get_name() const;
 
     /// Return the URL of the remote (e.g. "https://gitlab.com/a/b.git").
-    const std::string& get_url() const { return url_; }
+    std::string get_url() const;
 
     /**
      * Retrieve a list of references available on this remote repository
@@ -72,8 +73,6 @@ public:
     std::vector<std::string> list_references();
 
 private:
-    std::string name_;
-    std::string url_;
     LibGitRemote remote_{ nullptr, git_remote_free };
 };
 

--- a/include/libgit4cpp/Remote.h
+++ b/include/libgit4cpp/Remote.h
@@ -1,0 +1,72 @@
+/**
+ * \file   Remote.h
+ * \author Lars Fröhlich
+ * \date   Created on January 15, 2024
+ * \brief  Declaration of the Remote class.
+ *
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef LIBGIT4CPP_REMOTE_H_
+#define LIBGIT4CPP_REMOTE_H_
+
+#include <string>
+
+#include <git2.h>
+#include <gul14/optional.h>
+#include <gul14/SmallVector.h>
+
+#include "libgit4cpp/types.h"
+
+namespace git {
+
+/**
+ * An abstraction of a git remote (such as "origin").
+ *
+ * A remote has a name and a URL which can be accessed via get_name() and get_url(),
+ * respectively.
+ */
+class Remote
+{
+public:
+    /**
+     * Construct a Remote object by taking the ownership of a git_remote unique pointer.
+     * The constructor queries the name and URL of the remote and caches them for later
+     * access via get_name() and get_url().
+     * \exception Error is thrown if the given pointer is null.
+     */
+    Remote(LibGitRemote&& remote_ptr);
+
+    /// Return a non-owning pointer to the underlying git remote object.
+    git_remote* get() const { return remote_.get(); }
+
+    /// Return the name of the remote (e.g. "origin"). May be empty for in-memory remotes.
+    const std::string& get_name() const { return name_; }
+
+    /// Return the URL of the remote (e.g. "https://gitlab.com/a/b.git").
+    const std::string& get_url() const { return url_; }
+
+private:
+    std::string name_;
+    std::string url_;
+    LibGitRemote remote_{ nullptr, git_remote_free };
+};
+
+} // namespace git
+
+#endif

--- a/include/libgit4cpp/Remote.h
+++ b/include/libgit4cpp/Remote.h
@@ -61,6 +61,16 @@ public:
     /// Return the URL of the remote (e.g. "https://gitlab.com/a/b.git").
     const std::string& get_url() const { return url_; }
 
+    /**
+     * Retrieve a list of references available on this remote repository
+     * ("git ls-remote").
+     *
+     * \note
+     * The API for this function is preliminary. It would be more useful to return not
+     * just the names of the references, but also additional details like the commit IDs.
+     */
+    std::vector<std::string> list_references();
+
 private:
     std::string name_;
     std::string url_;

--- a/include/libgit4cpp/meson.build
+++ b/include/libgit4cpp/meson.build
@@ -3,6 +3,7 @@ public_headers = [
     'Error.h',
     'GitRepository.h',
     'libgit4cpp.h',
+    'Remote.h',
     'types.h',
     'wrapper_functions.h',
 ]

--- a/include/libgit4cpp/wrapper_functions.h
+++ b/include/libgit4cpp/wrapper_functions.h
@@ -120,12 +120,12 @@ LibGitRemote remote_create (git_repository* repo, const std::string& remote_name
                 const std::string& url);
 
 /**
- * Collects the remove connection by name.
+ * Find a remote repository by name.
  * \param repo Pointer to repository object
- * \param remote_name Name of the remote, e.g. "origin"
- * \return new git_remote object
+ * \param remote_name Name of the remote repository, e.g. "origin"
+ * \returns a pointer to a git_remote object (null if not found)
  */
-LibGitRemote remote_lookup (git_repository* repo, const std::string& remote_name);
+LibGitRemote remote_lookup(git_repository* repo, const std::string& remote_name);
 
 /**
  * Clone existing git repository into local filesystem.

--- a/include/libgit4cpp/wrapper_functions.h
+++ b/include/libgit4cpp/wrapper_functions.h
@@ -120,20 +120,21 @@ LibGitRemote remote_create (git_repository* repo, const std::string& remote_name
                 const std::string& url);
 
 /**
- * Find a remote repository by name.
- * \param repo Pointer to repository object
+ * Find a remote repository by the name under which it is configured in the given
+ * repository.
+ * \param repo Pointer to the repository object to search in
  * \param remote_name Name of the remote repository, e.g. "origin"
  * \returns a pointer to a git_remote object (null if not found)
  */
 LibGitRemote remote_lookup(git_repository* repo, const std::string& remote_name);
 
 /**
- * Clone existing git repository into local filesystem.
+ * Clone an existing git repository into the local filesystem.
  * \param url Address of remote connection, e.g https://github.com/...
  * \param repo_path Absolute or relative path to the repository root
  * \return new git_repository object
 */
-LibGitRepository clone (const std::string& url, const std::string& repo_path);
+LibGitRepository clone(const std::string& url, const std::string& repo_path);
 
 /**
  * Find a named branch.

--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,13 @@ deps = [
     dependency('libgit2')
 ]
 
+## libgit2 has an API change at some point; a check might become useful in the future
+#local_compiler_args = []
+#if dependency('libgit2').version().version_compare('<1')
+#    message('Ancient libgit2 version detected')
+#    local_compiler_args += [ '-DANCIENT_LIBGIT2' ]
+#endif
+
 lib = both_libraries('git4cpp',
     sources,
     dependencies : deps,

--- a/src/GitRepository.cc
+++ b/src/GitRepository.cc
@@ -483,7 +483,7 @@ void GitRepository::push(const Remote& remote, const std::string& refspec)
         throw Error{ cat("Cannot initialize remote callbacks for push: ",
             git_error_last()->message) };
     }
-    callbacks.credentials = credentials_callback;
+    callbacks.credentials = get_dummy_credentials_callback();
 
     git_push_options push_options;
     error = git_push_init_options(&push_options, GIT_PUSH_OPTIONS_VERSION);

--- a/src/GitRepository.cc
+++ b/src/GitRepository.cc
@@ -32,6 +32,7 @@
 #include "libgit4cpp/Error.h"
 #include "libgit4cpp/GitRepository.h"
 #include "libgit4cpp/wrapper_functions.h"
+#include "credentials_callback.h"
 
 using gul14::cat;
 
@@ -472,19 +473,6 @@ gul14::SmallVector<Remote, 2> GitRepository::list_remotes() const
 
     return result;
 }
-
-namespace {
-extern "C" {
-
-// Dummy credentials callback: Always return the same username and password
-int credentials_callback(git_cred** out, const char* /*url*/,
-    const char* /*username_from_url*/, unsigned int /*allowed_types*/, void* /*payload*/)
-{
-    return git_cred_userpass_plaintext_new(out, "user", "pwd");
-}
-
-} // extern "C"
-} // anonymous namespace
 
 void GitRepository::push(const Remote& remote, const std::string& refspec)
 {

--- a/src/GitRepository.cc
+++ b/src/GitRepository.cc
@@ -4,7 +4,7 @@
  * \date   Created on March 20, 2023
  * \brief  Implementation of the GitRepository class.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -27,6 +27,7 @@
 
 #include <git2.h>
 #include <gul14/cat.h>
+#include <gul14/finalizer.h>
 
 #include "libgit4cpp/Error.h"
 #include "libgit4cpp/GitRepository.h"
@@ -34,17 +35,11 @@
 
 namespace git {
 
-GitRepository::GitRepository(const std::filesystem::path& file_path, const std::string& url)
+GitRepository::GitRepository(const std::filesystem::path& file_path)
     : repo_path_{ file_path }
-    , url_{ url }
 {
     git_libgit2_init();
     init(file_path);
-
-    //check if remote already exists, else create new remote
-    auto remote_ = remote_lookup(repo_.get(), "origin");
-    if (not remote_ and not url.empty())
-        remote_ = remote_create(repo_.get(), "origin", url.c_str());
 }
 
 GitRepository::~GitRepository()
@@ -432,6 +427,7 @@ void GitRepository::reset(unsigned int nr_of_commits)
         throw git::Error{ gul14::cat("Reset: ", git_error_last()->message) };
 }
 
+#if 0
 void GitRepository::push()
 {
     // set options
@@ -452,7 +448,6 @@ void GitRepository::push()
     if (error)
         throw git::Error{ gul14::cat("Push remote: ", git_error_last()->message) };
 }
-
 
 void GitRepository::pull()
 {
@@ -496,7 +491,6 @@ void GitRepository::clone_repo(const std::string& url, const std::filesystem::pa
     }
 }
 
-
 bool GitRepository::branch_up_to_date(const std::string& branch_name)
 {
     auto local_ref = branch_lookup(repo_.get(), "master", GIT_BRANCH_LOCAL);
@@ -528,6 +522,7 @@ bool GitRepository::branch_up_to_date(const std::string& branch_name)
     // Compare OIDs to check if the branches are up to date
     return git_oid_equal(local_oid, remote_oid);
 }
+#endif
 
 } // namespace git
 

--- a/src/Remote.cc
+++ b/src/Remote.cc
@@ -39,12 +39,18 @@ Remote::Remote(LibGitRemote&& remote_ptr)
 {
     if (remote_ == nullptr)
         throw Error{ "Remote pointer may not be null" };
+}
 
+std::string Remote::get_name() const
+{
     const char* name = git_remote_name(remote_.get());
-    name_ = name ? name : "";
+    return name ? name : "";
+}
 
+std::string Remote::get_url() const
+{
     const char* url = git_remote_url(remote_.get());
-    url_ = url ? url : "";
+    return url ? url : "";
 }
 
 std::vector<std::string> Remote::list_references()
@@ -58,7 +64,7 @@ std::vector<std::string> Remote::list_references()
             nullptr, nullptr);
         if (error < 0)
         {
-            throw Error{ cat("Cannot connect to remote \"", name_, "\": ",
+            throw Error{ cat("Cannot connect to remote \"", get_name(), "\": ",
                 git_error_last()->message) };
         }
     }
@@ -68,7 +74,7 @@ std::vector<std::string> Remote::list_references()
     auto error = git_remote_ls(&out, &size, remote_.get());
     if (error)
     {
-        throw Error{ cat("Cannot list references on remote \"", name_, "\": ",
+        throw Error{ cat("Cannot list references on remote \"", get_name(), "\": ",
             git_error_last()->message) };
     }
 

--- a/src/Remote.cc
+++ b/src/Remote.cc
@@ -50,7 +50,7 @@ std::vector<std::string> Remote::list_references()
     if (!git_remote_connected(remote_.get()))
     {
         git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
-        callbacks.credentials = credentials_callback;
+        callbacks.credentials = get_dummy_credentials_callback();
 
         int error = git_remote_connect(remote_.get(), GIT_DIRECTION_FETCH, &callbacks,
             nullptr, nullptr);

--- a/src/Remote.cc
+++ b/src/Remote.cc
@@ -24,7 +24,6 @@
 
 #include <git2.h>
 #include <gul14/cat.h>
-#include <gul14/string_util.h>
 
 #include "libgit4cpp/Error.h"
 #include "libgit4cpp/Remote.h"
@@ -41,8 +40,11 @@ Remote::Remote(LibGitRemote&& remote_ptr)
     if (remote_ == nullptr)
         throw Error{ "Remote pointer may not be null" };
 
-    name_ = gul14::safe_string(git_remote_name(remote_.get()), 512);
-    url_ = gul14::safe_string(git_remote_url(remote_.get()), 512);
+    const char* name = git_remote_name(remote_.get());
+    name_ = name ? name : "";
+
+    const char* url = git_remote_url(remote_.get());
+    url_ = url ? url : "";
 }
 
 std::vector<std::string> Remote::list_references()

--- a/src/Remote.cc
+++ b/src/Remote.cc
@@ -1,0 +1,47 @@
+/**
+ * \file   Remote.cc
+ * \author Lars Fröhlich
+ * \date   Created on January 15, 2024
+ * \brief  Implementation of the Remote class.
+ *
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <git2.h>
+#include <gul14/cat.h>
+#include <gul14/string_util.h>
+
+#include "libgit4cpp/Error.h"
+#include "libgit4cpp/Remote.h"
+#include "libgit4cpp/wrapper_functions.h"
+
+using gul14::cat;
+
+namespace git {
+
+Remote::Remote(LibGitRemote&& remote_ptr)
+    : remote_{ std::move(remote_ptr) }
+{
+    if (remote_ == nullptr)
+        throw Error{ "Remote pointer may not be null" };
+
+    name_ = gul14::safe_string(git_remote_name(remote_.get()), 512);
+    url_ = gul14::safe_string(git_remote_url(remote_.get()), 512);
+}
+
+} // namespace git

--- a/src/credentials_callback.cc
+++ b/src/credentials_callback.cc
@@ -22,12 +22,11 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <git2.h>
+#include "credentials_callback.h"
 
-namespace git {
 extern "C" {
 
-int credentials_callback(git_cred** out_credentials, const char* /*url*/,
+static int dummy_credentials_callback(git_cred** out_credentials, const char* /*url*/,
     const char* /*username_from_url*/, unsigned int /*allowed_types*/, void* /*payload*/)
 {
     // Dummy implementation: Always return the same username and password
@@ -35,4 +34,13 @@ int credentials_callback(git_cred** out_credentials, const char* /*url*/,
 }
 
 } // extern "C"
+
+
+namespace git {
+
+CredentialsCallback get_dummy_credentials_callback()
+{
+    return dummy_credentials_callback;
+}
+
 } // namespace git

--- a/src/credentials_callback.cc
+++ b/src/credentials_callback.cc
@@ -1,0 +1,38 @@
+/**
+ * \file   credentials_callback.cc
+ * \author Lars Fröhlich
+ * \date   Created on January 16, 2024
+ * \brief  Implementation of the credentials callback function.
+ *
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <git2.h>
+
+namespace git {
+extern "C" {
+
+int credentials_callback(git_cred** out_credentials, const char* /*url*/,
+    const char* /*username_from_url*/, unsigned int /*allowed_types*/, void* /*payload*/)
+{
+    // Dummy implementation: Always return the same username and password
+    return git_cred_userpass_plaintext_new(out_credentials, "user", "pwd");
+}
+
+} // extern "C"
+} // namespace git

--- a/src/credentials_callback.h
+++ b/src/credentials_callback.h
@@ -25,20 +25,22 @@
 #ifndef LIBGIT4CPP_CREDENTIALS_CALLBACK_H_
 #define LIBGIT4CPP_CREDENTIALS_CALLBACK_H_
 
+#include <git2.h>
+
 namespace git {
-extern "C" {
+
+using CredentialsCallback
+    = int (*)(git_cred**, const char*, const char*, unsigned int, void*);
 
 /**
- * Credentials callback function for libgit2.
+ * Return a dummy credentials callback function for libgit2.
  *
- * This function is called by libgit2 when it needs credentials to access a remote, e.g.
- * over an HTTPS connection. Currently, this is just a dummy implementation that always
- * returns the same username and password.
+ * The returned function pointer may be called by libgit2 when it needs credentials to
+ * access a remote, e.g. over an HTTPS connection. Currently, this is just a dummy
+ * implementation that always returns the same username and password.
  */
-int credentials_callback(git_cred** out_credentials, const char* /*url*/,
-    const char* /*username_from_url*/, unsigned int /*allowed_types*/, void* /*payload*/);
+CredentialsCallback get_dummy_credentials_callback();
 
-} // extern "C"
 } // namespace git
 
 #endif

--- a/src/credentials_callback.h
+++ b/src/credentials_callback.h
@@ -1,0 +1,44 @@
+/**
+ * \file   credentials_callback.h
+ * \author Lars Fröhlich
+ * \date   Created on January 16, 2024
+ * \brief  Declaration of the credentials callback function.
+ *
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef LIBGIT4CPP_CREDENTIALS_CALLBACK_H_
+#define LIBGIT4CPP_CREDENTIALS_CALLBACK_H_
+
+namespace git {
+extern "C" {
+
+/**
+ * Credentials callback function for libgit2.
+ *
+ * This function is called by libgit2 when it needs credentials to access a remote, e.g.
+ * over an HTTPS connection. Currently, this is just a dummy implementation that always
+ * returns the same username and password.
+ */
+int credentials_callback(git_cred** out_credentials, const char* /*url*/,
+    const char* /*username_from_url*/, unsigned int /*allowed_types*/, void* /*payload*/);
+
+} // extern "C"
+} // namespace git
+
+#endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,5 @@
 sources = files(
     'GitRepository.cc',
+    'Remote.cc',
     'wrapper_functions.cc',
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,5 @@
 sources = files(
+    'credentials_callback.cc',
     'GitRepository.cc',
     'Remote.cc',
     'wrapper_functions.cc',

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -118,12 +118,9 @@ LibGitRemote remote_create(git_repository* repo, const std::string& remote_name,
 
 LibGitRemote remote_lookup(git_repository* repo, const std::string& remote_name)
 {
-    git_remote* remote;
-    if (git_remote_lookup(&remote, repo, remote_name.c_str()))
-    {
-        // gul14::cat("remote_lookup: ", git_error_last()->message);
-        remote = nullptr;
-    }
+    git_remote* remote = nullptr;
+    if (repo)
+        git_remote_lookup(&remote, repo, remote_name.c_str());
     return { remote, git_remote_free };
 }
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2,6 +2,7 @@
 test_src = files(
     'test_GitRepository.cc',
     'test_main.cc',
+    'test_Remote.cc',
 )
 
 # The tests are executed in the build dir to avoid pollution of the git repository with

--- a/tests/test_GitRepository.cc
+++ b/tests/test_GitRepository.cc
@@ -632,6 +632,34 @@ TEST_CASE("GitRepository: list_remotes(), add_remote()", "[GitRepository]")
     REQUIRE_THROWS_AS(repo.add_remote("origin", repo_url), git::Error);
 }
 
+TEST_CASE("GitRepository: list_remote_names(), add_remote()", "[GitRepository]")
+{
+    const auto folder = unit_test_folder() / "list_remote_names";
+
+    constexpr auto* repo_url
+        = "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git";
+
+    GitRepository repo{ folder };
+
+    // Repo list must be empty
+    auto remotes = repo.list_remote_names();
+    REQUIRE(remotes.empty());
+
+    // Add a remote
+    auto remote = repo.add_remote("origin", repo_url);
+    REQUIRE(remote.get() != nullptr);
+    REQUIRE(remote.get_name() == "origin");
+    REQUIRE(remote.get_url() == repo_url);
+
+    // Repo list must not be empty anymore
+    remotes = repo.list_remote_names();
+    REQUIRE(remotes.size() == 1);
+    REQUIRE(remotes[0] == "origin");
+
+    // Adding the same remote again must fail
+    REQUIRE_THROWS_AS(repo.add_remote("origin", repo_url), git::Error);
+}
+
 TEST_CASE("GitRepository: push()", "[GitRepository]")
 {
     const auto working_dir = unit_test_folder() / "push_test";

--- a/tests/test_GitRepository.cc
+++ b/tests/test_GitRepository.cc
@@ -4,7 +4,7 @@
  * \date   Created on March 22, 2023
  * \brief  Test suite for the GitRepository class.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -30,6 +30,7 @@
 #include <gul14/catch.h>
 #include <gul14/gul.h>
 
+#include "libgit4cpp/Error.h"
 #include "libgit4cpp/GitRepository.h"
 #include "libgit4cpp/wrapper_functions.h"
 
@@ -575,19 +576,18 @@ TEST_CASE("GitRepository add() with glob", "[GitWrapper]")
     }
 }
 
-
 /**
  * To test a remote repository, the following steps are executed
  * 1) Create a GitReposiotry with a link to a remote repository
  * 2) Commit and push files to remote repository (2x)
  * 3) Reset local repo to first commit and pull 2nd commit from remote
  * 4) Delete local repository and clone from remote
- * 
+ *
  * Tidy up) Reset remote, delete all local files
- 
+
 TEST_CASE("GitRepository Wrapper Test Remote", "[GitWrapper]")
 {
-    
+
 
     SECTION("Init empty GitRepository with remote connection")
     {

--- a/tests/test_GitRepository.cc
+++ b/tests/test_GitRepository.cc
@@ -592,12 +592,14 @@ TEST_CASE("GitRepository: get_remote(), add_remote()", "[GitRepository]")
 
     auto remote = repo.add_remote("origin", repo_url);
     REQUIRE(remote.get() != nullptr);
+    REQUIRE(remote.get_name() == "origin");
+    REQUIRE(remote.get_url() == repo_url);
 
     maybe_remote = repo.get_remote("origin");
     REQUIRE(maybe_remote.has_value());
+    REQUIRE(maybe_remote->get() != nullptr);
     REQUIRE(maybe_remote->get_name() == "origin");
     REQUIRE(maybe_remote->get_url() == repo_url);
-    REQUIRE(maybe_remote->get() != nullptr);
 }
 
 TEST_CASE("GitRepository: list_remotes(), add_remote()", "[GitRepository]")
@@ -615,16 +617,16 @@ TEST_CASE("GitRepository: list_remotes(), add_remote()", "[GitRepository]")
 
     // Add a remote
     auto remote = repo.add_remote("origin", repo_url);
+    REQUIRE(remote.get() != nullptr);
     REQUIRE(remote.get_name() == "origin");
     REQUIRE(remote.get_url() == repo_url);
-    REQUIRE(remote.get() != nullptr);
 
     // Repo list must not be empty anymore
     remotes = repo.list_remotes();
     REQUIRE(remotes.size() == 1);
+    REQUIRE(remotes[0].get() != nullptr);
     REQUIRE(remotes[0].get_name() == "origin");
     REQUIRE(remotes[0].get_url() == repo_url);
-    REQUIRE(remotes[0].get() != nullptr);
 
     // Adding the same remote again must fail
     REQUIRE_THROWS_AS(repo.add_remote("origin", repo_url), git::Error);

--- a/tests/test_GitRepository.cc
+++ b/tests/test_GitRepository.cc
@@ -33,13 +33,14 @@
 #include "libgit4cpp/Error.h"
 #include "libgit4cpp/GitRepository.h"
 #include "libgit4cpp/wrapper_functions.h"
+#include "test_main.h"
 
 using namespace git;
 using gul14::cat;
 
 namespace {
 
-auto const reporoot = std::filesystem::path{ "reporoot" };
+const auto reporoot = unit_test_folder() / "reporoot";
 
 /**
  * Create a directory and store files in it.

--- a/tests/test_Remote.cc
+++ b/tests/test_Remote.cc
@@ -43,8 +43,6 @@ TEST_CASE("Remote: Constructor", "[Remote]")
 {
     const auto reporoot = unit_test_folder() / "Remote";
 
-    std::filesystem::remove_all(reporoot);
-
     const std::string repo_url{
         "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git" };
 
@@ -68,9 +66,6 @@ TEST_CASE("Remote: list_references()", "[GitRepository]")
 {
     const auto working_dir = unit_test_folder() / "Remote_list_references";
     const auto remote_repo = unit_test_folder() / "Remote_list_references.remote";
-
-    std::filesystem::remove_all(working_dir);
-    std::filesystem::remove_all(remote_repo);
 
     // Create a local repository and commit a single file
     auto repo = std::make_unique<GitRepository>(working_dir);

--- a/tests/test_Remote.cc
+++ b/tests/test_Remote.cc
@@ -32,17 +32,16 @@
 #include "libgit4cpp/GitRepository.h"
 #include "libgit4cpp/Remote.h"
 #include "libgit4cpp/wrapper_functions.h"
+#include "test_main.h"
 
 using namespace git;
 using namespace std::literals;
 using gul14::cat;
 
-namespace {
-auto const reporoot = std::filesystem::path{ "reporoot" };
-} // anonymous namespace
-
 TEST_CASE("Remote: Constructor", "[Remote]")
 {
+    const auto reporoot = unit_test_folder() / "Remote";
+
     std::filesystem::remove_all(reporoot);
 
     const std::string repo_url{

--- a/tests/test_Remote.cc
+++ b/tests/test_Remote.cc
@@ -1,0 +1,65 @@
+/**
+ * \file   test_Remote.cc
+ * \author Lars Fröhlich
+ * \date   Created on January 15, 2024
+ * \brief  Test suite for the Remote class.
+ *
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <filesystem>
+
+#include <git2.h>
+#include <gul14/catch.h>
+#include <gul14/gul.h>
+
+#include "libgit4cpp/Error.h"
+#include "libgit4cpp/GitRepository.h"
+#include "libgit4cpp/Remote.h"
+#include "libgit4cpp/wrapper_functions.h"
+
+using namespace git;
+using namespace std::literals;
+using gul14::cat;
+
+namespace {
+auto const reporoot = std::filesystem::path{ "reporoot" };
+} // anonymous namespace
+
+TEST_CASE("Remote: Constructor", "[Remote]")
+{
+    std::filesystem::remove_all(reporoot);
+
+    const std::string repo_url{
+        "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git" };
+
+    GitRepository repo{ reporoot };
+
+    auto remote_ptr = remote_create(repo.get_repo(), "origin", repo_url);
+    REQUIRE(remote_ptr != nullptr);
+
+    Remote remote{ std::move(remote_ptr) };
+
+    REQUIRE(remote.get_name() == "origin"s);
+    REQUIRE(remote.get_url() == repo_url);
+
+    auto* re_ptr = remote.get();
+    REQUIRE(re_ptr != nullptr);
+    REQUIRE(git_remote_name(re_ptr) == "origin"s);
+    REQUIRE(git_remote_url(re_ptr) == repo_url);
+}

--- a/tests/test_main.h
+++ b/tests/test_main.h
@@ -1,10 +1,10 @@
 /**
- * \file   test_main.cc
+ * \file   test_main.h
  * \author Lars Fröhlich
- * \date   Created on November 26, 2019
- * \brief  Test suite for libgit4cpp
+ * \date   Created on January 16, 2024
+ * \brief  Declaration of global functions for the unit test suite.
  *
- * \copyright Copyright 2019-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,20 +22,4 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <filesystem>
-
-#define CATCH_CONFIG_RUNNER
-#include <gul14/catch.h>
-
-#include "test_main.h"
-
-std::filesystem::path unit_test_folder()
-{
-    return "unit_test_files";
-}
-
-int main(int argc, char* argv[])
-{
-    std::filesystem::remove_all(unit_test_folder());
-    return Catch::Session().run(argc, argv);
-}
+std::filesystem::path unit_test_folder();


### PR DESCRIPTION
This MR adds functionality for dealing with git remote repositories and for pushing refs from a local repository to a remote one. It disables the previous, incomplete implementation of `pull()` and related functionality.

The core is a new `Remote` class that encapsulates functionality for dealing with a git remote repository. The new `GitRepository` member functions `add_remote()`, `get_remote()`, and `list_remotes()` make use of it. In addition, the previous implementation of `push()` is made more functional by allowing the user to specify both a remote and a refspec (saying what should be pushed where).

As a drive-by cleanup, all files generated by unit tests are now collected under unit_test_files/.
