### PR TITLE
Rename GitRepository to Repository (breaking change)

### DIFF
--- a/include/libgit4cpp/Repository.h
+++ b/include/libgit4cpp/Repository.h
@@ -1,5 +1,5 @@
 /**
- * \file   GitRepository.h
+ * \file   Repository.h
  * \author Sven-Jannik Wöhnert
  * \date   Created on March 20, 2023
  * \brief  Wrapper for C-Package libgit2
@@ -22,8 +22,8 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef LIBGIT4CPP_GITREPOSITORY_H_
-#define LIBGIT4CPP_GITREPOSITORY_H_
+#ifndef LIBGIT4CPP_REPOSITORY_H_
+#define LIBGIT4CPP_REPOSITORY_H_
 
 #include <filesystem>
 #include <string>
@@ -74,7 +74,7 @@ inline std::ostream& operator<<(std::ostream& stream, const RepoState& repostate
  * git functions which are not implemented in this class will be
  * implemented in case of necessity
  */
-class GitRepository
+class Repository
 {
 public:
 
@@ -82,7 +82,7 @@ public:
      * Constructor which specifies the root dir of the git repository.
      * \param file_path  Path to git directory
      */
-    explicit GitRepository(const std::filesystem::path& file_path);
+    explicit Repository(const std::filesystem::path& file_path);
 
     /**
      * Reset all knowledge this object knows about the repository and load the knowledge again.
@@ -176,7 +176,7 @@ public:
      *            already exists.
      *
      * \code{.cpp}
-     * GitRepository repo{ "/path/to/repo" };
+     * Repository repo{ "/path/to/repo" };
      * repo.add_remote("origin", "https://gitlab.com/a/b.git");
      * repo.add_remote("upstream", "file:///path/to/upstream/repo");
      * \endcode
@@ -279,7 +279,7 @@ public:
     RepoState status();
 
     /// Destructor
-    ~GitRepository();
+    ~Repository();
 
 private:
 

--- a/include/libgit4cpp/libgit4cpp.h
+++ b/include/libgit4cpp/libgit4cpp.h
@@ -26,7 +26,7 @@
 #define LIBGIT4CPP_LIBGIT4CPP_H_
 
 #include "libgit4cpp/Error.h"
-#include "libgit4cpp/GitRepository.h"
+#include "libgit4cpp/Repository.h"
 #include "libgit4cpp/types.h"
 #include "libgit4cpp/wrapper_functions.h"
 

--- a/include/libgit4cpp/meson.build
+++ b/include/libgit4cpp/meson.build
@@ -1,7 +1,7 @@
 # The public_headers are tested for self-containment in the tests section
 public_headers = [
     'Error.h',
-    'GitRepository.h',
+    'Repository.h',
     'libgit4cpp.h',
     'Remote.h',
     'types.h',

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
 sources = files(
     'credentials_callback.cc',
-    'GitRepository.cc',
+    'Repository.cc',
     'Remote.cc',
     'wrapper_functions.cc',
 )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,8 +1,8 @@
 # Test sources
 test_src = files(
-    'test_GitRepository.cc',
     'test_main.cc',
     'test_Remote.cc',
+    'test_Repository.cc',
 )
 
 # The tests are executed in the build dir to avoid pollution of the git repository with

--- a/tests/test_Remote.cc
+++ b/tests/test_Remote.cc
@@ -30,7 +30,7 @@
 #include <gul14/gul.h>
 
 #include "libgit4cpp/Error.h"
-#include "libgit4cpp/GitRepository.h"
+#include "libgit4cpp/Repository.h"
 #include "libgit4cpp/Remote.h"
 #include "libgit4cpp/wrapper_functions.h"
 #include "test_main.h"
@@ -46,7 +46,7 @@ TEST_CASE("Remote: Constructor", "[Remote]")
     const std::string repo_url{
         "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git" };
 
-    GitRepository repo{ reporoot };
+    Repository repo{ reporoot };
 
     auto remote_ptr = remote_create(repo.get_repo(), "origin", repo_url);
     REQUIRE(remote_ptr != nullptr);
@@ -62,13 +62,13 @@ TEST_CASE("Remote: Constructor", "[Remote]")
     REQUIRE(git_remote_url(re_ptr) == repo_url);
 }
 
-TEST_CASE("Remote: list_references()", "[GitRepository]")
+TEST_CASE("Remote: list_references()", "[Remote]")
 {
     const auto working_dir = unit_test_folder() / "Remote_list_references";
     const auto remote_repo = unit_test_folder() / "Remote_list_references.remote";
 
     // Create a local repository and commit a single file
-    auto repo = std::make_unique<GitRepository>(working_dir);
+    auto repo = std::make_unique<Repository>(working_dir);
 
     std::ofstream f(working_dir / "test.txt");
     f << "Remote::list_references() test\n";

--- a/tests/test_Repository.cc
+++ b/tests/test_Repository.cc
@@ -1,8 +1,8 @@
 /**
- * \file   test_GitRepository.cc
+ * \file   test_Repository.cc
  * \author Sven-Jannik Wöhnert
  * \date   Created on March 22, 2023
- * \brief  Test suite for the GitRepository class.
+ * \brief  Test suite for the Repository class.
  *
  * \copyright Copyright 2023-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -31,7 +31,7 @@
 #include <gul14/gul.h>
 
 #include "libgit4cpp/Error.h"
-#include "libgit4cpp/GitRepository.h"
+#include "libgit4cpp/Repository.h"
 #include "libgit4cpp/wrapper_functions.h"
 #include "test_main.h"
 
@@ -74,7 +74,7 @@ void create_testfiles(const std::filesystem::path& name, size_t nr_files,
 
 } // anonymous namespace
 
-TEST_CASE("GitRepository Wrapper Test all", "[GitRepository]")
+TEST_CASE("Repository Wrapper Test all", "[Repository]")
 {
     /**
      * Create files in a directory and then initialize the git repository within.
@@ -84,12 +84,12 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitRepository]")
      * Check if a comit was created (initial commit)
      *
     */
-    SECTION("Construct GitRepository object")
+    SECTION("Construct Repository object")
     {
         std::filesystem::remove_all(reporoot);
         create_testfiles("unit_test_1", 2, "Construct");
 
-        GitRepository gl{ reporoot };
+        Repository gl{ reporoot };
 
         REQUIRE(not gl.get_path().empty());
         REQUIRE(gl.get_path() == reporoot);
@@ -112,7 +112,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitRepository]")
     {
         create_testfiles("unit_test_2", 2, "Stage");
 
-        GitRepository gl{ reporoot };
+        Repository gl{ reporoot };
 
         auto stats = gl.status();
         REQUIRE(stats.size() != 0);
@@ -152,7 +152,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitRepository]")
     {
 
         // Create Git Library
-        GitRepository gl{ reporoot };
+        Repository gl{ reporoot };
 
         auto stats = gl.status();
 
@@ -196,7 +196,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitRepository]")
     */
     SECTION("Add by path")
     {
-        GitRepository gl{ reporoot };
+        Repository gl{ reporoot };
 
         create_testfiles("unit_test_1", 2, "Add by path");
 
@@ -258,7 +258,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitRepository]")
     SECTION("Delete file")
     {
         // Create Git Library
-        GitRepository gl{ reporoot };
+        Repository gl{ reporoot };
 
         std::filesystem::path myfile = "unit_test_2/file1.txt";
         REQUIRE(std::filesystem::exists(gl.get_path() / myfile) == true);
@@ -287,7 +287,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitRepository]")
 
     SECTION("Get previous commit (git reset)")
     {
-        GitRepository gl{ reporoot };
+        Repository gl{ reporoot };
 
         std::stringstream ss{ };
         ss << gl.status();
@@ -332,7 +332,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitRepository]")
     SECTION("Delete Directory")
     {
         // Create Git Library
-        GitRepository gl{ reporoot };
+        Repository gl{ reporoot };
 
         std::filesystem::path mypath = "unit_test_2";
         REQUIRE(std::filesystem::exists(gl.get_path() / mypath) == true);
@@ -369,7 +369,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitRepository]")
 
     SECTION("Adding with glob (git add)")
     {
-        GitRepository gl{ reporoot };
+        Repository gl{ reporoot };
         auto ss = std::stringstream{ };
         ss << gl.status();
         REQUIRE(gul14::trim(ss.str()) == "RepoState {\n" \
@@ -392,7 +392,7 @@ TEST_CASE("GitRepository Wrapper Test all", "[GitRepository]")
     }
 }
 
-TEST_CASE("GitRepository add() with glob", "[GitRepository]")
+TEST_CASE("Repository add() with glob", "[Repository]")
 {
     std::filesystem::remove_all(reporoot);
     create_testfiles(".Atlantis", 1, "Atlantis");
@@ -404,7 +404,7 @@ TEST_CASE("GitRepository add() with glob", "[GitRepository]")
     create_testfiles("Malaysia", 1, "Kuala Lumpur");
     create_testfiles("Paraguay", 2, "Asuncion");
     create_testfiles("Peru", 2, "Lima");
-    GitRepository gl{ reporoot };
+    Repository gl{ reporoot };
     gl.reset(0);
 
     /**
@@ -578,14 +578,14 @@ TEST_CASE("GitRepository add() with glob", "[GitRepository]")
     }
 }
 
-TEST_CASE("GitRepository: get_remote(), add_remote()", "[GitRepository]")
+TEST_CASE("Repository: get_remote(), add_remote()", "[Repository]")
 {
     std::filesystem::remove_all(reporoot);
 
     constexpr auto* repo_url
         = "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git";
 
-    GitRepository repo{ reporoot };
+    Repository repo{ reporoot };
 
     auto maybe_remote = repo.get_remote("origin");
     REQUIRE(maybe_remote.has_value() == false);
@@ -602,14 +602,14 @@ TEST_CASE("GitRepository: get_remote(), add_remote()", "[GitRepository]")
     REQUIRE(maybe_remote->get_url() == repo_url);
 }
 
-TEST_CASE("GitRepository: list_remotes(), add_remote()", "[GitRepository]")
+TEST_CASE("Repository: list_remotes(), add_remote()", "[Repository]")
 {
     std::filesystem::remove_all(reporoot);
 
     constexpr auto* repo_url
         = "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git";
 
-    GitRepository repo{ reporoot };
+    Repository repo{ reporoot };
 
     // Repo list must be empty
     auto remotes = repo.list_remotes();
@@ -632,14 +632,14 @@ TEST_CASE("GitRepository: list_remotes(), add_remote()", "[GitRepository]")
     REQUIRE_THROWS_AS(repo.add_remote("origin", repo_url), git::Error);
 }
 
-TEST_CASE("GitRepository: list_remote_names(), add_remote()", "[GitRepository]")
+TEST_CASE("Repository: list_remote_names(), add_remote()", "[Repository]")
 {
     const auto folder = unit_test_folder() / "list_remote_names";
 
     constexpr auto* repo_url
         = "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git";
 
-    GitRepository repo{ folder };
+    Repository repo{ folder };
 
     // Repo list must be empty
     auto remotes = repo.list_remote_names();
@@ -660,7 +660,7 @@ TEST_CASE("GitRepository: list_remote_names(), add_remote()", "[GitRepository]")
     REQUIRE_THROWS_AS(repo.add_remote("origin", repo_url), git::Error);
 }
 
-TEST_CASE("GitRepository: push()", "[GitRepository]")
+TEST_CASE("Repository: push()", "[Repository]")
 {
     const auto working_dir = unit_test_folder() / "push_test";
     const auto remote_repo = unit_test_folder() / "push_test_remote";
@@ -669,7 +669,7 @@ TEST_CASE("GitRepository: push()", "[GitRepository]")
     std::filesystem::remove_all(remote_repo);
 
     // Create a local repository
-    GitRepository repo{ working_dir };
+    Repository repo{ working_dir };
 
     // Commit a single file
     std::ofstream f(working_dir / "test.txt");
@@ -702,22 +702,22 @@ TEST_CASE("GitRepository: push()", "[GitRepository]")
 
 /**
  * To test a remote repository, the following steps are executed
- * 1) Create a GitReposiotry with a link to a remote repository
+ * 1) Create a Repository with a link to a remote repository
  * 2) Commit and push files to remote repository (2x)
  * 3) Reset local repo to first commit and pull 2nd commit from remote
  * 4) Delete local repository and clone from remote
  *
  * Tidy up) Reset remote, delete all local files
 
-TEST_CASE("GitRepository Wrapper Test Remote", "[GitWrapper]")
+TEST_CASE("Repository Wrapper Test Remote", "[GitWrapper]")
 {
 
 
-    SECTION("Init empty GitRepository with remote connection")
+    SECTION("Init empty Repository with remote connection")
     {
         std::filesystem::remove_all(reporoot);
 
-        GitRepository gl{ reporoot, "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git" };
+        Repository gl{ reporoot, "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git" };
 
         REQUIRE(not gl.get_path().empty());
         REQUIRE(gl.get_path() == reporoot);
@@ -732,7 +732,7 @@ TEST_CASE("GitRepository Wrapper Test Remote", "[GitWrapper]")
 
     SECTION("make commit and push to remote repository")
     {
-        GitRepository gl{ reporoot, "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git" };
+        Repository gl{ reporoot, "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git" };
 
         create_testfiles("unit_test_1", 2, "commit and push");
 
@@ -764,7 +764,7 @@ TEST_CASE("GitRepository Wrapper Test Remote", "[GitWrapper]")
 
     SECTION("Reset repository to former commit and pull current commit from remote repository")
     {
-        GitRepository gl{ reporoot, "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git" };
+        Repository gl{ reporoot, "https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git" };
 
         //second commit
         create_testfiles("unit_test_2", 1, "commit and push 2");
@@ -792,7 +792,7 @@ TEST_CASE("GitRepository Wrapper Test Remote", "[GitWrapper]")
 
 
         //clone reposiotry from remote
-        GitRepository gl{ reporoot };
+        Repository gl{ reporoot };
         gl.clone_repo("https://gitlab.desy.de/jannik.woehnert/taskolib_remote_test.git", reporoot);
 
         REQUIRE(gl.get_last_commit_message() == "Second commit");


### PR DESCRIPTION
[why]  
The "Git" part of the name is superfluous, esp if given the full specified name is "git::GitRepository".

Compare also discussion in #18