### PR TITLE
Implement checkout wrapper with parameter for partial checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/html/
 .vscode/settings.json
 .vscode/cspell.json
 unit_test_files/
+sequences/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ docs/html/
 .vscode/settings.json
 .vscode/cspell.json
 unit_test_files/
-sequences/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,6 +4,7 @@
             "name": "Ubuntu-x64",
             "includePath": [
                 "${workspaceFolder}/**",
+                "/export/doocs/lib/include",
                 "/export/doocs/lib/include"
             ],
             "browse": {

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,6 @@
             "name": "Ubuntu-x64",
             "includePath": [
                 "${workspaceFolder}/**",
-                "/export/doocs/lib/include",
                 "/export/doocs/lib/include"
             ],
             "browse": {

--- a/include/libgit4cpp/Repository.h
+++ b/include/libgit4cpp/Repository.h
@@ -63,7 +63,7 @@ inline std::ostream& operator<<(std::ostream& stream, const RepoState& repostate
     return stream;
 }
 
-enum class BranchType {ALL = 0, LOCAL =1, REMOTE=2};
+enum class BranchType {all = 0, local =1, remote=2};
 
 
 /**
@@ -251,7 +251,8 @@ public:
      * \param origin_branch_name name of the existing branch to checkout from
      * \return The reference object of the new branch
     */
-    LibGitReference new_branch(const std::string& branch_name, const std::string& origin_branch_name);
+    LibGitReference new_branch(const std::string& branch_name,
+        const std::string& origin_branch_name);
 
     /**
      * Returns the active branch in the repository.
@@ -264,16 +265,18 @@ public:
      * \param type_flag defines which types of branches should be listed
      * \return vector of branch longnames
      */
-    std::vector<std::string> list_branches(BranchType type_flag = BranchType::ALL);
+    std::vector<std::string> list_branches(BranchType type_flag = BranchType::all);
 
     /**
      * Check out selected files from branch.
      * The path parameter takes a list of files, directories. It supports pattern matching
-     * \attention GIT_FORCE flag is used. It may overwrite uncommitted changes in the current branch 
+     * \attention GIT_FORCE flag is used. It may overwrite uncommitted changes in the
+     *            current branch
      * \param branch_name The branch to checkout
      * \param paths specifies the files to checkout
      */
-    void checkout(const std::string& branch_name, const std::vector<std::string>& paths = {"*"});
+    void checkout(const std::string& branch_name,
+        const std::vector<std::string>& paths = {"*"});
 
     /**
      * Switch branches by setting HEAD to an existing branch.

--- a/include/libgit4cpp/Repository.h
+++ b/include/libgit4cpp/Repository.h
@@ -233,7 +233,13 @@ public:
      * \param branch_name
     */
     bool branch_up_to_date(const std::string& branch_name);
+
 #endif
+
+    /**
+     * Checkout a branch with options
+    */
+    void checkout(const std::string& branch_name, const std::string& paths = "*");
 
     /**
      * Remove all entries from the index under a given directory.

--- a/include/libgit4cpp/Repository.h
+++ b/include/libgit4cpp/Repository.h
@@ -248,12 +248,15 @@ public:
      * \param branch_name name of the new branch
      * \param origin_branch_name name of the existing branch to checkout from
     */
-    LibGitReference new_branch(const std::string& branch_name, const:std::string& origin_branch_name);
+    LibGitReference new_branch(const std::string& branch_name, const std::string& origin_branch_name);
 
     /**
-     * Checkout a branch with options
+     * Checkout a branch with options.
+     * The path parameter takes a list of files, directories. It supports pattern matching
+     * \param branch_name The branch to checkout
+     * \param paths specifies the files to checkout
     */
-    void checkout(const std::string& branch_name, const std::string& paths = "*");
+    void checkout(const std::string& branch_name, const std::vector<std::string>& paths);
 
     /**
      * Remove all entries from the index under a given directory.

--- a/include/libgit4cpp/Repository.h
+++ b/include/libgit4cpp/Repository.h
@@ -247,6 +247,7 @@ public:
      * Create a new branch from a specified existing branch.
      * \param branch_name name of the new branch
      * \param origin_branch_name name of the existing branch to checkout from
+     * \return The reference object of the new branch
     */
     LibGitReference new_branch(const std::string& branch_name, const std::string& origin_branch_name);
 

--- a/include/libgit4cpp/Repository.h
+++ b/include/libgit4cpp/Repository.h
@@ -251,9 +251,20 @@ public:
     LibGitReference new_branch(const std::string& branch_name, const std::string& origin_branch_name);
 
     /**
-     * Returns the active branch in the repository
+     * Returns the active branch in the repository.
+     * \return shorthand name of current branch (eg. master)
     */
     std::string get_current_branch();
+
+    /**
+     * List the longnames of all branches.
+     * \param type_flag defines which types of branches should be listed
+     *  0 -> All
+     *  1 -> Local
+     *  2 -> Remote
+     * \return vector of branch longnames
+    */
+    std::vector<std::string> list_branches(int type_flag = 0);
 
     /**
      * Checkout a branch with options.
@@ -262,6 +273,14 @@ public:
      * \param paths specifies the files to checkout
     */
     void checkout(const std::string& branch_name, const std::vector<std::string>& paths = {"*"});
+
+    /**
+     * Switch branches by setting HEAD to an existing branch.
+     * \attention If the branch doesn't exist yet, no error will be thrown.
+     *            The HEAD will then be attached to an unborn branch.
+     * \param branch_name ID, shorthand or full reference name of branch
+    */
+   void switch_branch(const std::string& branch_name);
 
     /**
      * Remove all entries from the index under a given directory.

--- a/include/libgit4cpp/Repository.h
+++ b/include/libgit4cpp/Repository.h
@@ -236,6 +236,20 @@ public:
 
 #endif
 
+
+    /**
+     * Create a new branch from the current branch.
+     * \param branch_name name of the new branch
+    */
+    void new_branch(const std::string& branch_name);
+
+    /**
+     * Create a new branch from a specified existing branch.
+     * \param branch_name name of the new branch
+     * \param origin_branch_name name of the existing branch to checkout from
+    */
+    void new_branch(const std::string& branch_name, const:std::string& origin_branch_name);
+
     /**
      * Checkout a branch with options
     */

--- a/include/libgit4cpp/Repository.h
+++ b/include/libgit4cpp/Repository.h
@@ -251,12 +251,17 @@ public:
     LibGitReference new_branch(const std::string& branch_name, const std::string& origin_branch_name);
 
     /**
+     * Returns the active branch in the repository
+    */
+    std::string get_current_branch();
+
+    /**
      * Checkout a branch with options.
      * The path parameter takes a list of files, directories. It supports pattern matching
      * \param branch_name The branch to checkout
      * \param paths specifies the files to checkout
     */
-    void checkout(const std::string& branch_name, const std::vector<std::string>& paths);
+    void checkout(const std::string& branch_name, const std::vector<std::string>& paths = {"*"});
 
     /**
      * Remove all entries from the index under a given directory.

--- a/include/libgit4cpp/Repository.h
+++ b/include/libgit4cpp/Repository.h
@@ -241,14 +241,14 @@ public:
      * Create a new branch from the current branch.
      * \param branch_name name of the new branch
     */
-    void new_branch(const std::string& branch_name);
+    LibGitReference new_branch(const std::string& branch_name);
 
     /**
      * Create a new branch from a specified existing branch.
      * \param branch_name name of the new branch
      * \param origin_branch_name name of the existing branch to checkout from
     */
-    void new_branch(const std::string& branch_name, const:std::string& origin_branch_name);
+    LibGitReference new_branch(const std::string& branch_name, const:std::string& origin_branch_name);
 
     /**
      * Checkout a branch with options

--- a/include/libgit4cpp/Repository.h
+++ b/include/libgit4cpp/Repository.h
@@ -63,6 +63,8 @@ inline std::ostream& operator<<(std::ostream& stream, const RepoState& repostate
     return stream;
 }
 
+enum class BranchType {ALL = 0, LOCAL =1, REMOTE=2};
+
 
 /**
  * A class to wrap used methods from C-Library libgit2.
@@ -166,7 +168,7 @@ public:
     /**
      * Hard reset of repository.
      * \param nr_of_commits number of commits to jump back
-    */
+     */
     void reset(unsigned int nr_of_commits);
 
     /**
@@ -225,13 +227,13 @@ public:
     /**
      * Clone a repository.
      * \param addr Address of the git repository host
-    */
+     */
     void clone_repo(const std::string& url, const std::filesystem::path& repo_path);
 
     /**
      * Check if remote and local branch are in same state.
      * \param branch_name
-    */
+     */
     bool branch_up_to_date(const std::string& branch_name);
 
 #endif
@@ -240,7 +242,7 @@ public:
     /**
      * Create a new branch from the current branch.
      * \param branch_name name of the new branch
-    */
+     */
     LibGitReference new_branch(const std::string& branch_name);
 
     /**
@@ -254,25 +256,23 @@ public:
     /**
      * Returns the active branch in the repository.
      * \return shorthand name of current branch (eg. master)
-    */
-    std::string get_current_branch();
+     */
+    std::string get_current_branch_name();
 
     /**
      * List the longnames of all branches.
      * \param type_flag defines which types of branches should be listed
-     *  0 -> All
-     *  1 -> Local
-     *  2 -> Remote
      * \return vector of branch longnames
-    */
-    std::vector<std::string> list_branches(int type_flag = 0);
+     */
+    std::vector<std::string> list_branches(BranchType type_flag = BranchType::ALL);
 
     /**
-     * Checkout a branch with options.
+     * Check out selected files from branch.
      * The path parameter takes a list of files, directories. It supports pattern matching
+     * \attention GIT_FORCE flag is used. It may overwrite uncommitted changes in the current branch 
      * \param branch_name The branch to checkout
      * \param paths specifies the files to checkout
-    */
+     */
     void checkout(const std::string& branch_name, const std::vector<std::string>& paths = {"*"});
 
     /**
@@ -312,7 +312,7 @@ public:
      * \param filepaths list of files
      * \attention files in filepaths are relative to repo_path_
      * \see remove_directory()
-    */
+     */
     void remove_files(const std::vector<std::filesystem::path>& filepaths);
 
     /**

--- a/include/libgit4cpp/types.h
+++ b/include/libgit4cpp/types.h
@@ -39,6 +39,7 @@ using LibGitCommit = std::unique_ptr<git_commit, void(*)(git_commit*)>;
 using LibGitStatusList = std::unique_ptr<git_status_list, void(*)(git_status_list*)>;
 using LibGitReference = std::unique_ptr<git_reference, void(*)(git_reference*)>;
 using LibGitBuf = std::unique_ptr<git_buf, void(*)(git_buf*)>;
+using LibGitBranchIterator = std::unique_ptr<git_branch_iterator, void(*)(git_branch_iterator*)>;
 
 } // namespace git
 

--- a/include/libgit4cpp/wrapper_functions.h
+++ b/include/libgit4cpp/wrapper_functions.h
@@ -194,6 +194,20 @@ std::string reference_name(git_reference* ref);
 */
 LibGitReference parse_reference_from_name(git_repository* repo, const std::string& name);
 
+/**
+ * returns an iterator of the branches.
+*/
+LibGitBranchIterator branch_iterator(git_repository* repo, git_branch_t flag);
+
+/**
+ * Iterates branches over an iterator object.
+ * \exception ref will be nullptr only if ieration object reached its end.
+ *  otherwise exception will be thrown
+ * \param branch_type defines if iterator is for local or remote branches
+ * \param iter iterator object 
+*/
+LibGitReference branch_next(git_branch_t* branch_type, git_branch_iterator* iter);
+
 /** \} */ // end of group lgptrfunc
 
 } // namespace git

--- a/include/libgit4cpp/wrapper_functions.h
+++ b/include/libgit4cpp/wrapper_functions.h
@@ -56,14 +56,14 @@ LibGitRepository repository_open(const std::string& repo_path);
  * \param repo_path Absolute or relative path to the repository root
  * \param is_bare If true, a git repo is created at repo_path. Else, .git is created in repo_path.
  * \return new git_repository object for the created repository
-*/
+ */
 LibGitRepository repository_init(const std::string& repo_path, bool is_bare);
 
 /**
  * Return the current index of a repository.
  * \param repo Pointer to the repository object
  * \return new git_index object
-*/
+ */
 LibGitIndex repository_index(git_repository* repo);
 
 /**
@@ -81,7 +81,7 @@ LibGitSignature signature_default(git_repository* repo);
  * \param time Unix time of the creation date
  * \param offset Timezone adjustment for the timestamp
  * \return new git_signature object
-*/
+ */
 LibGitSignature signature_new(const std::string& name, const std::string& email, time_t time, int offset);
 
 
@@ -90,7 +90,7 @@ LibGitSignature signature_new(const std::string& name, const std::string& email,
  * \param repo Pointer to repository object to examine
  * \param tree_id Identity number of the active tree
  * \return new git_tree object
-*/
+ */
 LibGitTree tree_lookup(git_repository* repo, git_oid tree_id);
 
 /**
@@ -99,7 +99,7 @@ LibGitTree tree_lookup(git_repository* repo, git_oid tree_id);
  * \param repo Pointer to repository object
  * \param status_opt Struct of status options
  * \return new git_status_list object
-*/
+ */
 LibGitStatusList status_list_new(git_repository* repo, const git_status_options& status_opt);
 
 /**
@@ -133,7 +133,7 @@ LibGitRemote remote_lookup(git_repository* repo, const std::string& remote_name)
  * \param url Address of remote connection, e.g https://github.com/...
  * \param repo_path Absolute or relative path to the repository root
  * \return new git_repository object
-*/
+ */
 LibGitRepository clone(const std::string& url, const std::string& repo_path);
 
 /**
@@ -142,7 +142,7 @@ LibGitRepository clone(const std::string& url, const std::string& repo_path);
  * \param branch_name The name to search for, e.g. 'main', 'fix-bugs'
  * \param branch_type Which branch type to find, enum with 1=GIT_BRANCH_LOCAL, 2=GIT_BRANCH_REMOTE, 3=GIT_BRANCH_ALL
  * \return new git_reference object
-*/
+ */
 LibGitReference branch_lookup(git_repository* repo, const std::string& branch_name, git_branch_t branch_type);
 
 
@@ -150,7 +150,7 @@ LibGitReference branch_lookup(git_repository* repo, const std::string& branch_na
  * Get the tree of a commit.
  * \param libgit2 git_commit pointer
  * \return git_tree wrapper
-*/
+ */
 LibGitTree commit_tree(git_commit* commit);
 
 
@@ -158,9 +158,10 @@ LibGitTree commit_tree(git_commit* commit);
  * Create a new branch.
  * \param repo Pointer to repository object
  * \param new_branch_name The name of the new branch
- * \param branch_type Which branch type to find, enum with 1=GIT_BRANCH_LOCAL, 2=GIT_BRANCH_REMOTE, 3=GIT_BRANCH_ALL
+ * \param starting_commit reference object from where to branch out
+ * \param force if True, it will force the creation even with uncommited changes
  * \return new git_reference object
-*/
+ */
 LibGitReference branch_create(git_repository* repo, const std::string& new_branch_name, const git_commit* starting_commit, int force);
 
 /**
@@ -168,22 +169,22 @@ LibGitReference branch_create(git_repository* repo, const std::string& new_branc
  * \param repo Pointer to repository object
  * \param branch_name Local branch name, e.g. 'main', 'fix-bugs'
  * \return name on remote , e.g. 'origin/main' or 'origin/fix-bugs'
-*/
+ */
 std::string branch_remote_name(git_repository* repo, const std::string& branch_name);
 
 /**
- * Returns the human-readbale name of a reference.
+ * Returns the human-readable name of a reference.
  * It is required for functions like \c git::branch_lookup() which requires a name instead of a reference object
  * \param ref constant git_reference object
  * \return readable name of reference (e.g. master, main, ...)
-*/
+ */
 std::string reference_shorthand(const git_reference* ref);
 
 /**
  * Get full name of a reference.
  * \param ref libgit2 reference object
  * \return full name of reference (e.g. "refs/heads/master" == full name of "master")
-*/
+ */
 std::string reference_name(git_reference* ref);
 
 /**
@@ -191,21 +192,25 @@ std::string reference_name(git_reference* ref);
  * \param repo Pointer to repository object
  * \param name specification of reference (eg. refs/heads/master, main, e934a2, master@{2}, ...)
  * \return reference object
-*/
+ */
 LibGitReference parse_reference_from_name(git_repository* repo, const std::string& name);
 
 /**
  * returns an iterator of the branches.
-*/
+ * \param repo Pointer to repository object
+ * \param flag bitwise flag libgit2 object.
+ *      choices: GIT_BRANCH_LOCAL, GIT_BRANCH_REMOTE, GIT_BRANCH_ALL
+ * \return iterator for existing branches
+ */
 LibGitBranchIterator branch_iterator(git_repository* repo, git_branch_t flag);
 
 /**
  * Iterates branches over an iterator object.
- * \exception ref will be nullptr only if ieration object reached its end.
+ * \exception ref will be nullptr only if iteration object reached its end.
  *  otherwise exception will be thrown
  * \param branch_type defines if iterator is for local or remote branches
  * \param iter iterator object 
-*/
+ */
 LibGitReference branch_next(git_branch_t* branch_type, git_branch_iterator* iter);
 
 /** \} */ // end of group lgptrfunc

--- a/include/libgit4cpp/wrapper_functions.h
+++ b/include/libgit4cpp/wrapper_functions.h
@@ -179,6 +179,21 @@ std::string branch_remote_name(git_repository* repo, const std::string& branch_n
 */
 std::string reference_shorthand(const git_reference* ref);
 
+/**
+ * Get full name of a reference.
+ * \param ref libgit2 reference object
+ * \return full name of reference (e.g. "refs/heads/master" == full name of "master")
+*/
+std::string reference_name(git_reference* ref);
+
+/**
+ * Find reference object from shortname, longname or id specification.
+ * \param repo Pointer to repository object
+ * \param name specification of reference (eg. refs/heads/master, main, e934a2, master@{2}, ...)
+ * \return reference object
+*/
+LibGitReference parse_reference_from_name(git_repository* repo, const std::string& name);
+
 /** \} */ // end of group lgptrfunc
 
 } // namespace git

--- a/include/libgit4cpp/wrapper_functions.h
+++ b/include/libgit4cpp/wrapper_functions.h
@@ -147,13 +147,21 @@ LibGitReference branch_lookup(git_repository* repo, const std::string& branch_na
 
 
 /**
+ * Get the tree of a commit.
+ * \param libgit2 git_commit pointer
+ * \return git_tree wrapper
+*/
+LibGitTree commit_tree(git_commit* commit);
+
+
+/**
  * Create a new branch.
  * \param repo Pointer to repository object
  * \param new_branch_name The name of the new branch
  * \param branch_type Which branch type to find, enum with 1=GIT_BRANCH_LOCAL, 2=GIT_BRANCH_REMOTE, 3=GIT_BRANCH_ALL
  * \return new git_reference object
 */
-LibGitReference branch_create(git_repository* repo, std::string& new_branch_name);
+LibGitReference branch_create(git_repository* repo, const std::string& new_branch_name, const git_commit* starting_commit, int force);
 
 /**
  * Find the name of a branch on the remote.

--- a/include/libgit4cpp/wrapper_functions.h
+++ b/include/libgit4cpp/wrapper_functions.h
@@ -145,6 +145,16 @@ LibGitRepository clone(const std::string& url, const std::string& repo_path);
 */
 LibGitReference branch_lookup(git_repository* repo, const std::string& branch_name, git_branch_t branch_type);
 
+
+/**
+ * Create a new branch.
+ * \param repo Pointer to repository object
+ * \param new_branch_name The name of the new branch
+ * \param branch_type Which branch type to find, enum with 1=GIT_BRANCH_LOCAL, 2=GIT_BRANCH_REMOTE, 3=GIT_BRANCH_ALL
+ * \return new git_reference object
+*/
+LibGitReference branch_create(git_repository* repo, std::string& new_branch_name);
+
 /**
  * Find the name of a branch on the remote.
  * \param repo Pointer to repository object
@@ -152,6 +162,14 @@ LibGitReference branch_lookup(git_repository* repo, const std::string& branch_na
  * \return name on remote , e.g. 'origin/main' or 'origin/fix-bugs'
 */
 std::string branch_remote_name(git_repository* repo, const std::string& branch_name);
+
+/**
+ * Returns the human-readbale name of a reference.
+ * It is required for functions like \c git::branch_lookup() which requires a name instead of a reference object
+ * \param ref constant git_reference object
+ * \return readable name of reference (e.g. master, main, ...)
+*/
+std::string reference_shorthand(const git_reference* ref);
 
 /** \} */ // end of group lgptrfunc
 

--- a/src/Repository.cc
+++ b/src/Repository.cc
@@ -665,11 +665,14 @@ void Repository::checkout(const std::string& branch_name,
     checkout_opts.checkout_strategy = GIT_CHECKOUT_FORCE;
 
     // find latest commit of said branch
-    auto full_branch_name = reference_name(parse_reference_from_name(repo_.get(), branch_name).get());
+    auto full_branch_name = reference_name(
+        parse_reference_from_name(repo_.get(), branch_name).get());
     auto last_commit = get_commit(full_branch_name);
 
-    // checkout
-    auto error = git_checkout_tree(repo_.get(), (const git_object*) last_commit.get(), &checkout_opts);
+    // checkout (the cast is necessary because libgit2 simulates inheritance by having a
+    // struct git_object as the first member of the opaque struct git_commit)
+    auto error = git_checkout_tree(repo_.get(),
+        reinterpret_cast<const git_object*>(last_commit.get()), &checkout_opts);
     if (error)
         throw Error{ cat("Checkout: ", git_error_last()->message) };
 }

--- a/src/Repository.cc
+++ b/src/Repository.cc
@@ -600,7 +600,8 @@ LibGitReference Repository::new_branch(const std::string& branch_name)
     return new_branch(branch_name, get_current_branch_name());
 }
 
-LibGitReference Repository::new_branch(const std::string& branch_name, const std::string& origin_branch_name)
+LibGitReference Repository::new_branch(const std::string& branch_name,
+    const std::string& origin_branch_name)
 {
     // checkout origin branch
     auto ref = branch_lookup(repo_.get(), origin_branch_name, GIT_BRANCH_LOCAL);
@@ -625,15 +626,19 @@ std::vector<std::string> Repository::list_branches(BranchType type_flag)
 {
     // transform libgit4cpp enum into libgit2 object
     git_branch_t flag;
-    if      (type_flag == BranchType::ALL) flag = GIT_BRANCH_ALL;
-    else if (type_flag == BranchType::LOCAL) flag = GIT_BRANCH_LOCAL;
-    else if (type_flag == BranchType::REMOTE) flag = GIT_BRANCH_REMOTE;
-    else throw Error{"list_branches: unknown type_flag"};
+    if (type_flag == BranchType::all)
+        flag = GIT_BRANCH_ALL;
+    else if (type_flag == BranchType::local)
+        flag = GIT_BRANCH_LOCAL;
+    else if (type_flag == BranchType::remote)
+        flag = GIT_BRANCH_REMOTE;
+    else
+        throw Error{"list_branches: unknown type_flag"};
 
     std::vector<std::string> ret;
 
     LibGitBranchIterator iter = branch_iterator(repo_.get(), flag);
-    
+
     LibGitReference ref = branch_next(&flag, iter.get());
     while(ref != nullptr)
     {
@@ -643,9 +648,10 @@ std::vector<std::string> Repository::list_branches(BranchType type_flag)
     return ret;
 }
 
-void Repository::checkout(const std::string& branch_name, const std::vector<std::string>& paths)
+void Repository::checkout(const std::string& branch_name,
+    const std::vector<std::string>& paths)
 {
-     
+
     git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
     // define the paths of files to checkout
     checkout_opts.paths.count = paths.size();
@@ -657,7 +663,7 @@ void Repository::checkout(const std::string& branch_name, const std::vector<std:
     checkout_opts.paths.strings = const_cast<char **>(paths_as_cstr.data());
 
     checkout_opts.checkout_strategy = GIT_CHECKOUT_FORCE;
-  
+
     // find latest commit of said branch
     auto full_branch_name = reference_name(parse_reference_from_name(repo_.get(), branch_name).get());
     auto last_commit = get_commit(full_branch_name);
@@ -678,7 +684,7 @@ void Repository::switch_branch(const std::string& branch_name)
     int error = git_repository_set_head(repo_.get(), branch_full_name.c_str());
     if (error)
         throw Error{ cat("switch_branch: ", git_error_last()->message) };
-    
+
     // go back to original state on this branch
     reset(0);
 }

--- a/src/Repository.cc
+++ b/src/Repository.cc
@@ -595,7 +595,7 @@ bool Repository::branch_up_to_date(const std::string& branch_name)
 #endif
 
 
-void Repository::new_branch(const std::string& branch_name)
+LibGitReference Repository::new_branch(const std::string& branch_name)
 {
     // get current HEAD
     auto head = repository_head(repo_.get());
@@ -604,16 +604,21 @@ void Repository::new_branch(const std::string& branch_name)
     std::string origin_branch_name = reference_shorthand(head);
 
     // create branch
-    new_branch(branch_name, origin_branch_name);
+    return new_branch(branch_name, origin_branch_name);
 }
 
-void Repository::new_branch(const std::string& branch_name, const:std::string& origin_branch_name)
+LibGitReference Repository::new_branch(const std::string& branch_name, const:std::string& origin_branch_name)
 {
     // checkout origin branch
     auto ref = branch_lookup(repo_.get(), origin_branch_name, GIT_BRANCH_LOCAL);
 
+    // get latest commit
+    auto commit = get_commit(reference_shorthand(ref));
+
     // create new branch
-    //branch_create();
+    LibGitReference ref = branch_create(git_repository* repo, std::string& new_branch_name, commit.get());
+
+    return ref;
 }
 
 void Repository::checkout(const std::string& branch_name, const std::vector<std::string>& paths)

--- a/src/Repository.cc
+++ b/src/Repository.cc
@@ -594,6 +594,28 @@ bool Repository::branch_up_to_date(const std::string& branch_name)
 }
 #endif
 
+
+void Repository::new_branch(const std::string& branch_name)
+{
+    // get current HEAD
+    auto head = repository_head(repo_.get());
+
+    // get branch name from HEAD
+    std::string origin_branch_name = reference_shorthand(head);
+
+    // create branch
+    new_branch(branch_name, origin_branch_name);
+}
+
+void Repository::new_branch(const std::string& branch_name, const:std::string& origin_branch_name)
+{
+    // checkout origin branch
+    auto ref = branch_lookup(repo_.get(), origin_branch_name, GIT_BRANCH_LOCAL);
+
+    // create new branch
+    //branch_create();
+}
+
 void Repository::checkout(const std::string& branch_name, const std::vector<std::string>& paths)
 {
      

--- a/src/Repository.cc
+++ b/src/Repository.cc
@@ -594,6 +594,27 @@ bool Repository::branch_up_to_date(const std::string& branch_name)
 }
 #endif
 
+void Repository::checkout(const std::string& branch_name, const std::vector<std::string>& paths)
+{
+     
+    git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
+    // define the paths of files to checkout
+    checkout_opts.paths.count = paths.size();
+    checkout_opts.paths.strings = (char **) paths.data();
+    // dont enforce checkout (all changes must be committed) 
+    checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
+  
+    // find latest commit of said branch
+    auto last_commit = get_commit(branch_name);
+
+    auto tree = commit_tree(last_commit.get());
+
+    error = git_checkout_tree(repo.get(), tree.get(), &checkout_opts)
+    if (error)
+        throw Error{ cat("Checkout: ", git_error_last()->message) };
+}
+
+
 } // namespace git
 
 // vi:ts=4:sw=4:sts=4:et

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -192,4 +192,12 @@ std::string branch_remote_name(git_repository* repo, const std::string& branch_n
     return ret;
 }
 
+std::string reference_shorthand(const git_reference* ref)
+{
+    const char* name_cstr = git_reference_shorthand(ref);
+    if (name_cstr == nullptr)
+        throw Error{gul14::cat("reference_shorthand: ", git_error_last()->message) };
+    return std::string(name_cstr);
+}
+
 } // namespace git

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -170,6 +170,16 @@ LibGitReference branch_lookup(git_repository* repo, const std::string& branch_na
     return { ref, git_reference_free };
 }
 
+LibGitTree commit_tree(git_commit* commit)
+{
+    git_tree* tree;
+    if (git_commit_tree(&tree, commit))
+    {
+        tree = nullptr;
+    }
+    return { tree, git_tree_free };
+}
+
 std::string branch_remote_name(git_repository* repo, const std::string& branch_name)
 {
     git_buf buf{ };

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -216,21 +216,6 @@ std::string reference_name(git_reference* ref)
     return std::string(name_cstr);
 }
 
-/*
-LibGitReference parse_reference_from_name(git_repository* repo, const std::string& name)
-{
-    git_object* ref;
-    auto error = git_revparse_single(&ref, repo, name.c_str());
-    if (error)
-        throw Error{gul14::cat("parse_reference_from_name: ", git_error_last()->message) };
-    if (git_object_type(ref) != GIT_OBJ_REF_DELTA)
-        throw Error{gul14::cat("parse_reference_from_name: found object from type ",
-                                git_object_type2string(git_object_type(ref)),
-                                " instead of reference") };
-    return {(git_reference*) ref, git_reference_free};
-}
-*/
-
 LibGitReference parse_reference_from_name(git_repository* repo, const std::string& name)
 {
     git_reference* ref;

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -180,6 +180,14 @@ LibGitTree commit_tree(git_commit* commit)
     return { tree, git_tree_free };
 }
 
+LibGitReference branch_create(git_repository* repo, std::string& new_branch_name, const git_commit* starting_commit, int force)
+{
+    git_reference* ref;
+    if(git_branch_create(&ref, repo, new_branch_name.c_str(), starting_commit, force))
+        ref = nullptr;
+    return {ref, git_reference_free};
+}
+
 std::string branch_remote_name(git_repository* repo, const std::string& branch_name)
 {
     git_buf buf{ };

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -208,4 +208,36 @@ std::string reference_shorthand(const git_reference* ref)
     return std::string(name_cstr);
 }
 
+std::string reference_name(git_reference* ref)
+{
+    const char* name_cstr = git_reference_name(ref);
+    if (name_cstr == nullptr)
+        throw Error{gul14::cat("reference_name: ", git_error_last()->message) };
+    return std::string(name_cstr);
+}
+
+/*
+LibGitReference parse_reference_from_name(git_repository* repo, const std::string& name)
+{
+    git_object* ref;
+    auto error = git_revparse_single(&ref, repo, name.c_str());
+    if (error)
+        throw Error{gul14::cat("parse_reference_from_name: ", git_error_last()->message) };
+    if (git_object_type(ref) != GIT_OBJ_REF_DELTA)
+        throw Error{gul14::cat("parse_reference_from_name: found object from type ",
+                                git_object_type2string(git_object_type(ref)),
+                                " instead of reference") };
+    return {(git_reference*) ref, git_reference_free};
+}
+*/
+
+LibGitReference parse_reference_from_name(git_repository* repo, const std::string& name)
+{
+    git_reference* ref;
+    auto error = git_reference_dwim(&ref, repo, name.c_str());
+    if (error)
+        throw Error{gul14::cat("parse_reference_from_name: ", git_error_last()->message) };
+    return {ref, git_reference_free};
+}
+
 } // namespace git

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -180,7 +180,7 @@ LibGitTree commit_tree(git_commit* commit)
     return { tree, git_tree_free };
 }
 
-LibGitReference branch_create(git_repository* repo, std::string& new_branch_name, const git_commit* starting_commit, int force)
+LibGitReference branch_create(git_repository* repo, const std::string& new_branch_name, const git_commit* starting_commit, int force)
 {
     git_reference* ref;
     if(git_branch_create(&ref, repo, new_branch_name.c_str(), starting_commit, force))

--- a/src/wrapper_functions.cc
+++ b/src/wrapper_functions.cc
@@ -240,4 +240,22 @@ LibGitReference parse_reference_from_name(git_repository* repo, const std::strin
     return {ref, git_reference_free};
 }
 
+LibGitBranchIterator branch_iterator(git_repository* repo, git_branch_t flag)
+{
+    git_branch_iterator* iter;
+    auto error = git_branch_iterator_new(&iter, repo, flag);
+    if (error)
+        throw Error{gul14::cat("get_branch_iterator: ", git_error_last()->message) };
+    return {iter, git_branch_iterator_free};
+}
+
+LibGitReference branch_next(git_branch_t* branch_type, git_branch_iterator* iter)
+{
+    git_reference* ref;
+    int error = git_branch_next(&ref, branch_type, iter);
+    if (error == GIT_ITEROVER)
+        ref = nullptr;
+    return {ref, git_reference_free};
+}
+
 } // namespace git

--- a/tests/test_Repository.cc
+++ b/tests/test_Repository.cc
@@ -703,6 +703,26 @@ TEST_CASE("Repository: push()", "[Repository]")
     REQUIRE(std::find(refs.begin(), refs.end(), "refs/heads/main"s) != refs.end());
 }
 
+TEST_CASE("Repository: checkout new branch", "[Repository]")
+{
+    // create test files
+
+    // create repository
+
+    // create new branch
+
+    // check reference shortname
+
+    // create new test files
+
+    // check last commit
+
+    // checkout to original branch
+
+    // check last commit
+    
+}
+
 /**
  * To test a remote repository, the following steps are executed
  * 1) Create a Repository with a link to a remote repository

--- a/tests/test_Repository.cc
+++ b/tests/test_Repository.cc
@@ -705,6 +705,13 @@ TEST_CASE("Repository: push()", "[Repository]")
 
 TEST_CASE("Repository: checkout new branch", "[Repository]")
 {
+    /**
+     * The test refers to the term "checkout" mainly
+     * because it is used to switch the HEAD in the command line with
+     * e.g. "git checkout feature/cool_feature".
+     * The real checkout is tested in partial checkout in the
+     * following test.
+    */
     // create test files
     std::filesystem::remove_all(reporoot);
     create_testfiles("checkout_test", 2, "new");
@@ -719,7 +726,10 @@ TEST_CASE("Repository: checkout new branch", "[Repository]")
 
     // create new branch
     repo.new_branch("new_branch");
-    repo.checkout("new_branch", {"*"});
+    repo.switch_branch("new_branch");
+
+    auto branches = repo.list_branches(1);
+    REQUIRE(branches.size() == 2);
 
     // check reference shortname
     REQUIRE(repo.get_current_branch() == "new_branch");
@@ -740,7 +750,7 @@ TEST_CASE("Repository: checkout new branch", "[Repository]")
     REQUIRE(repo.get_last_commit_message() == "Commit on new branch");
 
     // checkout to original branch
-    repo.checkout("main", {"*"});
+    repo.switch_branch("main");
 
     // check last commit
     REQUIRE(repo.get_last_commit_message() == "Second commit on main branch");

--- a/tests/test_Repository.cc
+++ b/tests/test_Repository.cc
@@ -100,7 +100,7 @@ TEST_CASE("Repository Wrapper Test all", "[Repository]")
         REQUIRE(gl.get_last_commit_message() == "Initial commit");
 
         // We have no remote at this point
-        REQUIRE_THROWS(branch_remote_name(gl.get_repo(), "master"));
+        REQUIRE_THROWS(branch_remote_name(gl.get_repo(), "main"));
     }
 
 
@@ -714,18 +714,41 @@ TEST_CASE("Repository: checkout new branch", "[Repository]")
     repo.add();
     repo.commit("Second commit on main branch");
 
+    // check origin branch
+    REQUIRE(repo.get_current_branch() == "main");
+
     // create new branch
+    repo.new_branch("new_branch");
+    repo.checkout("new_branch", {"*"});
 
     // check reference shortname
+    REQUIRE(repo.get_current_branch() == "new_branch");
+    REQUIRE(repo.get_last_commit_message() == "Second commit on main branch");
 
     // create new test files
+    // file_0 stays the same
+    // file_1 changes
+    // file_2 new file
+    create_testfiles("checkout_test", 3, "branch_file");
+    create_testfiles("checkout_test", 1, "new");
+
+    // apply changes
+    repo.add();
+    repo.commit("Commit on new branch");
 
     // check last commit
+    REQUIRE(repo.get_last_commit_message() == "Commit on new branch");
 
     // checkout to original branch
+    repo.checkout("main", {"*"});
 
     // check last commit
-    
+    REQUIRE(repo.get_last_commit_message() == "Second commit on main branch");
+}
+
+TEST_CASE("Repository: partially checkout other branch", "[Repository]")
+{
+
 }
 
 /**
@@ -781,12 +804,12 @@ TEST_CASE("Repository Wrapper Test Remote", "[GitWrapper]")
         }
 
         // check if remote and local repo are not in the same state
-        REQUIRE( ! gl.branch_up_to_date("master"));
+        REQUIRE( ! gl.branch_up_to_date("main"));
 
         gl.push();
 
         // check if remote and local repo are in same state
-        REQUIRE( gl.branch_up_to_date("master"));
+        REQUIRE( gl.branch_up_to_date("main"));
 
     }
 
@@ -800,16 +823,16 @@ TEST_CASE("Repository Wrapper Test Remote", "[GitWrapper]")
         gl.commit("Second commit");
         gl.push();
 
-        REQUIRE( gl.branch_up_to_date("master"));
+        REQUIRE( gl.branch_up_to_date("main"));
 
         // reset local repository
         gl.reset(1);
 
-        REQUIRE_FALSE( gl.branch_up_to_date("master"));
+        REQUIRE_FALSE( gl.branch_up_to_date("main"));
 
         gl.pull();
 
-        REQUIRE( gl.branch_up_to_date("master"));
+        REQUIRE( gl.branch_up_to_date("main"));
     }
 
 

--- a/tests/test_Repository.cc
+++ b/tests/test_Repository.cc
@@ -83,7 +83,7 @@ TEST_CASE("Repository Wrapper Test all", "[Repository]")
      * Check if a repository is created (HEAD exists)
      * Check if a comit was created (initial commit)
      *
-    */
+     */
     SECTION("Construct Repository object")
     {
         std::filesystem::remove_all(reporoot);
@@ -196,7 +196,7 @@ TEST_CASE("Repository Wrapper Test all", "[Repository]")
      * 2) check if status of them is modified, but unstaged
      * 3) stage file1 of unit_test_1
      * 4) file1 should be staged and file0 still be unstaged
-    */
+     */
     SECTION("Add by path")
     {
         Repository gl{ reporoot };
@@ -711,7 +711,7 @@ TEST_CASE("Repository: checkout new branch", "[Repository]")
      * e.g. "git checkout feature/cool_feature".
      * The real checkout is tested in partial checkout in the
      * following test.
-    */
+     */
     // create test files
     std::filesystem::remove_all(reporoot);
     create_testfiles("checkout_test", 2, "new");
@@ -722,17 +722,17 @@ TEST_CASE("Repository: checkout new branch", "[Repository]")
     repo.commit("Second commit on main branch");
 
     // check origin branch
-    REQUIRE(repo.get_current_branch() == "main");
+    REQUIRE(repo.get_current_branch_name() == "main");
 
     // create new branch
     repo.new_branch("new_branch");
     repo.switch_branch("new_branch");
 
-    auto branches = repo.list_branches(1);
+    auto branches = repo.list_branches(BranchType::LOCAL);
     REQUIRE(branches.size() == 2);
 
     // check reference shortname
-    REQUIRE(repo.get_current_branch() == "new_branch");
+    REQUIRE(repo.get_current_branch_name() == "new_branch");
     REQUIRE(repo.get_last_commit_message() == "Second commit on main branch");
 
     // create new test files

--- a/tests/test_Repository.cc
+++ b/tests/test_Repository.cc
@@ -706,8 +706,13 @@ TEST_CASE("Repository: push()", "[Repository]")
 TEST_CASE("Repository: checkout new branch", "[Repository]")
 {
     // create test files
+    std::filesystem::remove_all(reporoot);
+    create_testfiles("checkout_test", 2, "new");
 
     // create repository
+    Repository repo {reporoot};
+    repo.add();
+    repo.commit("Second commit on main branch");
 
     // create new branch
 

--- a/tests/test_Repository.cc
+++ b/tests/test_Repository.cc
@@ -728,7 +728,7 @@ TEST_CASE("Repository: checkout new branch", "[Repository]")
     repo.new_branch("new_branch");
     repo.switch_branch("new_branch");
 
-    auto branches = repo.list_branches(BranchType::LOCAL);
+    auto branches = repo.list_branches(BranchType::local);
     REQUIRE(branches.size() == 2);
 
     // check reference shortname
@@ -809,7 +809,7 @@ TEST_CASE("Repository: partially checkout other branch", "[Repository]")
         "FileStatus{ \"partial_checkout_test/file2.txt\": staged; new file }\n" \
         "FileStatus{ \"partial_checkout_test/file3.txt\": staged; new file }\n" \
         "}");
-    
+
 
     // reset to last commit and partial checkout of one file
     repo.reset(0);


### PR DESCRIPTION
[why]
This implementation serves as a preparation to exchange sequences between VXFEL and XFEL repository.

[what]
A git_checkout_options instance is created and the path specifier is implemented within. I used C type conversion for std::string to git_strarray, probably there is a better way to do this.
To receive the latest commit of said branch, the function checkout assumes that within repo_ variable, there is already the branch we want to checkout from. If not, the Error handling is done already in the function get_commit.
After we retrieved the branch, we collect the whole tree to be able to use the libgit2 function git_checkout_tree.
For this, it was necessary to create a wrapper for git_commit_tree

[next]
I will also implement tests for this. I decided to already open a pull request so that you can  "add your mustard" as soon as possible.
And documentation of the code...
