### PR TITLE
Use Catch2v3 for the unit test suite

### DIFF
--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -45,7 +45,7 @@ jobs:
       uses: robinraju/release-downloader@v1.6
       with:
         repository: "mesonbuild/meson"
-        tag: "0.53.2"
+        tag: "1.7.0"
         fileName: "*.tar.gz"
     - name: Unpack meson tar ball and remove downloaded file
       run: |
@@ -61,8 +61,8 @@ jobs:
 
     - name: Configure build directories
       run: |
-        ./meson.py --buildtype=release build.release
-        ./meson.py --buildtype=debug build.asan -Db_sanitize=address
+        ./meson.py setup --buildtype=release build.release
+        ./meson.py setup --buildtype=debug build.asan -Db_sanitize=address
     - name: Build and run release tests
       id: buildnormal
       run: ./meson.py test -C build.release

--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -28,7 +28,7 @@ jobs:
     name: Build and Tests
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
     runs-on: ${{ matrix.os }}
     steps:
     - run: |
@@ -68,7 +68,7 @@ jobs:
       run: ./meson.py test -C build.release
 
     - name: Save error logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.buildnormal.outcome == 'failure' }}
       with:
         name: Meson-logs-${{ matrix.os }}
@@ -79,7 +79,7 @@ jobs:
       run: ./meson.py test -C build.asan
 
     - name: Save error logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.buildasan.outcome == 'failure' }}
       with:
         name: Meson-logs-${{ matrix.os }}

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Jannik Woehnert <jannik.woehnert@desy.de>
 Standards-Version: 4.6.0
-Build-Depends: dev-doocs-libgul14 | libgul14-dev, meson (>=0.50.0), pkg-config, debhelper-compat (=12), libgit2-dev
+Build-Depends: dev-doocs-libgul14 | libgul14-dev, meson (>=0.50.0), pkg-config, debhelper-compat (=12), catch2 (>>3.4.0), libgit2-dev
 
 Package: libgit4cpp-0-4-8
 Section: libs

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Jannik Woehnert <jannik.woehnert@desy.de>
 Standards-Version: 4.6.0
-Build-Depends: dev-doocs-libgul14 | libgul14-dev, meson (>=0.50.0), pkg-config, debhelper-compat (=12), catch2 (>>3.4.0), libgit2-dev
+Build-Depends: dev-doocs-libgul14 | libgul14-dev, meson (>=0.50.0), pkg-config, debhelper-compat (=12), catch2 (>=3.4.0) | libcatch2, libgit2-dev
 
 Package: libgit4cpp-0-4-8
 Section: libs

--- a/subprojects/catch2.wrap
+++ b/subprojects/catch2.wrap
@@ -1,0 +1,9 @@
+[wrap-git]
+directory = catch2
+url = https://github.com/catchorg/Catch2.git
+revision = v3.8.0
+
+[provide]
+dependency_names = catch2_dep, catch2_with_main_dep
+catch2 = catch2_dep
+catch2_with_main = catch2_with_main_dep

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -12,7 +12,7 @@ test('all',
     executable(meson.project_name() + '_test',
         test_src,
         dependencies : [
-            dependency('catch2'),
+            dependency('catch2', version : '>3.4.0'),
             libgit4cpp_dep,
         ],
     ),

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -12,7 +12,7 @@ test('all',
     executable(meson.project_name() + '_test',
         test_src,
         dependencies : [
-            dependency('catch2', version : '>3.4.0'),
+            dependency('catch2', version : '>=3.4.0'),
             libgit4cpp_dep,
         ],
     ),

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,7 +11,10 @@ test_src = files(
 test('all',
     executable(meson.project_name() + '_test',
         test_src,
-        dependencies : libgit4cpp_dep,
+        dependencies : [
+            dependency('catch2'),
+            libgit4cpp_dep,
+        ],
     ),
     workdir : meson.current_build_dir(),
     timeout : 10,

--- a/tests/test_Error.cc
+++ b/tests/test_Error.cc
@@ -1,9 +1,10 @@
 /**
- * \file   test_Error.cc
- * \date   Created on January 23, 2024
- * \brief  Test suite for the git::Error exception class.
+ * \file    test_Error.cc
+ * \authors Fini Jastrow, Lars Fröhlich
+ * \date    Created on January 23, 2024
+ * \brief   Test suite for the git::Error exception class.
  *
- * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2024-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -23,7 +24,7 @@
 
 #include <string>
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include "libgit4cpp/Error.h"
 

--- a/tests/test_Remote.cc
+++ b/tests/test_Remote.cc
@@ -4,7 +4,7 @@
  * \date   Created on January 15, 2024
  * \brief  Test suite for the Remote class.
  *
- * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2024-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,8 +25,8 @@
 #include <filesystem>
 #include <fstream>
 
+#include <catch2/catch_test_macros.hpp>
 #include <git2.h>
-#include <gul14/catch.h>
 #include <gul14/gul.h>
 
 #include "libgit4cpp/Error.h"

--- a/tests/test_Repository.cc
+++ b/tests/test_Repository.cc
@@ -4,7 +4,7 @@
  * \date   Created on March 22, 2023
  * \brief  Test suite for the Repository class.
  *
- * \copyright Copyright 2023-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,8 +26,8 @@
 #include <fstream>
 #include <iostream>
 
+#include <catch2/catch_test_macros.hpp>
 #include <git2.h>
-#include <gul14/catch.h>
 #include <gul14/gul.h>
 
 #include "libgit4cpp/Error.h"

--- a/tests/test_main.cc
+++ b/tests/test_main.cc
@@ -4,7 +4,7 @@
  * \date   Created on November 26, 2019
  * \brief  Test suite for libgit4cpp
  *
- * \copyright Copyright 2019-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2019-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,8 +24,7 @@
 
 #include <filesystem>
 
-#define CATCH_CONFIG_RUNNER
-#include <gul14/catch.h>
+#include <catch2/catch_session.hpp>
 
 #include "test_main.h"
 


### PR DESCRIPTION
This moves from the old header-only Catch2 version 2.x included in GUL14 to the newer 3.x family of the unit test framework. Accordingly, the header files that need to be included change.