### PR TITLE
tests: Fix rethrowing exception

### DIFF
--- a/tests/test_Remote.cc
+++ b/tests/test_Remote.cc
@@ -122,7 +122,7 @@ TEST_CASE("wrapper_functions: branch_remote_name()", "[Remote]")
         if (e.code() == git::git_error_code::GIT_EAMBIGUOUS) {
             REQUIRE(false); // will not happen
         }
-        throw e;
+        throw;
     }
     REQUIRE(name_str == "origin"s);
 


### PR DESCRIPTION
[why]
This is just the wrong approach, rethrow should be done with the throw keyword without parameters.

See
https://github.com/taskolib/taskolib/pull/129