### PR TITLE
Meson: Replace homebrew catch2 wrap file with WrapDB one

### DIFF
--- a/subprojects/catch2.wrap
+++ b/subprojects/catch2.wrap
@@ -1,9 +1,11 @@
-[wrap-git]
-directory = catch2
-url = https://github.com/catchorg/Catch2.git
-revision = v3.8.0
+[wrap-file]
+directory = Catch2-3.8.1
+source_url = https://github.com/catchorg/Catch2/archive/v3.8.1.tar.gz
+source_filename = Catch2-3.8.1.tar.gz
+source_hash = 18b3f70ac80fccc340d8c6ff0f339b2ae64944782f8d2fca2bd705cf47cadb79
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.8.1-1/Catch2-3.8.1.tar.gz
+wrapdb_version = 3.8.1-1
 
 [provide]
-dependency_names = catch2_dep, catch2_with_main_dep
 catch2 = catch2_dep
-catch2_with_main = catch2_with_main_dep
+catch2-with-main = catch2_with_main_dep


### PR DESCRIPTION
This replaces the previous wrap file with the latest "official" one from the WrapDB under https://mesonbuild.com/Wrapdb-projects.html.